### PR TITLE
Add Streamlit UI starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # movieAgent
 Local Streamlit agent: spreadsheet-managed prompts → Ollama/ComfyUI/framepack video → auto-post to SNS
+
+## Setup
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Run
+
+```bash
+streamlit run app.py
+```
+
+Access the UI in your browser at [http://localhost:8501](http://localhost:8501).

--- a/app.py
+++ b/app.py
@@ -1,0 +1,6 @@
+import streamlit as st
+
+st.set_page_config(page_title="Video Agent", layout="wide")
+
+st.title("Streamlit Video Agent")
+st.write("This is the initial UI. Replace with actual features.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+streamlit


### PR DESCRIPTION
## Summary
- add `requirements.txt` with Streamlit
- create initial Streamlit UI app
- document setup and run instructions

## Testing
- `streamlit run app.py --help` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb1a8567483299710016eae2628d1