### PR TITLE
Add spreadsheet UI using st-aggrid

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,57 @@
 import streamlit as st
+import pandas as pd
+from st_aggrid import AgGrid, GridOptionsBuilder, GridUpdateMode
+
+CSV_FILE = "videos.csv"
+
+
+def load_data(path: str) -> pd.DataFrame:
+    columns = [
+        "title",
+        "synopsis",
+        "story_prompt",
+        "bgm_prompt",
+        "taste_prompt",
+        "character_voice",
+        "status",
+        "needs_approve",
+    ]
+    try:
+        df = pd.read_csv(path)
+    except FileNotFoundError:
+        df = pd.DataFrame(columns=columns)
+    else:
+        missing_cols = [c for c in columns if c not in df.columns]
+        for c in missing_cols:
+            df[c] = ""
+        df = df[columns]
+    return df
+
+
+def save_data(df: pd.DataFrame, path: str) -> None:
+    df.to_csv(path, index=False)
 
 st.set_page_config(page_title="Video Agent", layout="wide")
 
 st.title("Streamlit Video Agent")
-st.write("This is the initial UI. Replace with actual features.")
+
+data = load_data(CSV_FILE)
+
+st.write("### Video Spreadsheet")
+
+gb = GridOptionsBuilder.from_dataframe(data)
+gb.configure_default_column(editable=True)
+options = gb.build()
+
+grid_return = AgGrid(
+    data,
+    gridOptions=options,
+    update_mode=GridUpdateMode.VALUE_CHANGED,
+    fit_columns_on_grid_load=True,
+)
+
+updated_df = grid_return["data"]
+
+if st.button("Save changes"):
+    save_data(updated_df, CSV_FILE)
+    st.success("Saved to CSV")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 streamlit
+streamlit-aggrid
+pandas

--- a/videos.csv
+++ b/videos.csv
@@ -1,0 +1,2 @@
+title,synopsis,story_prompt,bgm_prompt,taste_prompt,character_voice,status,needs_approve
+Sample Video,Sample synopsis,Sample story prompt,lofi science,flat comic,cheerful female,sheet,Y


### PR DESCRIPTION
## Summary
- set up `streamlit-aggrid` and `pandas`
- display `videos.csv` in an editable grid
- allow saving the modified table
- include sample CSV data

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_686c558efdcc83299e65ad3784613ad2