### PR TITLE
Fix missing st_aggrid handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ streamlit run app.py
 ```
 
 実行後、ブラウザで [http://localhost:8501](http://localhost:8501) を開くと UI が表示されます。
+
+### トラブルシューティング
+
+`ModuleNotFoundError: No module named 'st_aggrid'` が表示された場合は、依存パッケージが不足しています。以下のコマンドで追加インストールしてから再度起動してください。
+
+```bash
+pip install streamlit-aggrid
+```

--- a/app.py
+++ b/app.py
@@ -1,6 +1,10 @@
 import streamlit as st
 import pandas as pd
-from st_aggrid import AgGrid, GridOptionsBuilder, GridUpdateMode
+
+try:
+    from st_aggrid import AgGrid, GridOptionsBuilder, GridUpdateMode
+except ModuleNotFoundError:
+    AgGrid = GridOptionsBuilder = GridUpdateMode = None
 
 CSV_FILE = "videos.csv"
 
@@ -38,6 +42,11 @@ st.title("Streamlit Video Agent")
 data = load_data(CSV_FILE)
 
 st.write("### Video Spreadsheet")
+
+if AgGrid is None:
+    st.error("Required package 'streamlit-aggrid' is not installed.\n"
+             "Please run `pip install streamlit-aggrid` and restart the app.")
+    st.stop()
 
 gb = GridOptionsBuilder.from_dataframe(data)
 gb.configure_default_column(editable=True)


### PR DESCRIPTION
## Summary
- handle `ModuleNotFoundError` for st_aggrid in Streamlit app
- add troubleshooting note about installing `streamlit-aggrid`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686c56bd278083299079f6f7f0a51928