### PR TITLE
Enable model selection and Ollama integration

### DIFF
--- a/videos.csv
+++ b/videos.csv
@@ -1,2 +1,2 @@
-title,synopsis,story_prompt,bgm_prompt,taste_prompt,character_voice,status,needs_approve
-Sample Video,Sample synopsis,Sample story prompt,lofi science,flat comic,cheerful female,sheet,Y
+title,synopsis,llm_model,story_prompt,bgm_prompt,taste_prompt,character_voice,status,needs_approve
+Sample Video,Sample synopsis,phi3:mini,Sample story prompt,lofi science,flat comic,cheerful female,sheet,Y


### PR DESCRIPTION
## Summary
- add ability to choose an Ollama model for each row
- dynamically list models using `ollama list`
- generate `story_prompt` from synopsis via selected model
- store model selection in a new `llm_model` column

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686c80fc289883299b8811f271cf7954