### PR TITLE
Add parameter controls for LLM generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,6 @@ streamlit run app.py
 
 
 動画リストは **Streamlit Data Editor** を利用しており、`num_rows="dynamic"`
-を指定することで、表から直接行を追加・削除できます。
+を指定することで、表から直接行を追加・削除できます。モデルの選択に加え、
+`temperature`、`max_tokens`、`top_p` といった生成パラメータも列として編集
+可能です。

--- a/videos.csv
+++ b/videos.csv
@@ -1,2 +1,2 @@
-title,synopsis,llm_model,story_prompt,bgm_prompt,taste_prompt,character_voice,status,needs_approve
-Sample Video,Sample synopsis,phi3:mini,Sample story prompt,lofi science,flat comic,cheerful female,sheet,Y
+title,synopsis,llm_model,temperature,max_tokens,top_p,story_prompt,bgm_prompt,taste_prompt,character_voice,status,needs_approve
+Sample Video,Sample synopsis,phi3:mini,0.7,200,0.95,Sample story prompt,lofi science,flat comic,cheerful female,sheet,Y


### PR DESCRIPTION
## Summary
- add temperature, max_tokens and top_p columns to the spreadsheet
- allow editing of these parameters in Streamlit
- pass the parameters to `ollama run`
- update sample CSV and README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686ca9a9e3108329885cfeb447c69f6b