### PR TITLE
Enable auto-save and refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,6 @@ streamlit run app.py
 `temperature`、`max_tokens`、`top_p` といった生成パラメータも列として編集
 可能です。
 デフォルト値は `temperature=0.7`、`max_tokens=4096`、`top_p=0.95` です。
+
+"Generate story prompts" ボタンを押すと、選択された行のプロンプト生成後に
+CSV へ自動保存し、ページをリフレッシュして結果を即座に反映します。

--- a/app.py
+++ b/app.py
@@ -193,6 +193,8 @@ if st.button("Generate story prompts", disabled=generate_disabled):
             if prompt is not None:
                 df.at[idx, "story_prompt"] = prompt
     st.session_state.video_df = df
+    save_data(df, CSV_FILE)
+    st.experimental_rerun()
 
 if st.button("Save changes"):
     save_data(st.session_state.video_df, CSV_FILE)


### PR DESCRIPTION
## Summary
- auto-save to CSV and rerun the app after generating prompts
- document the automatic refresh behavior

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686cd08bfbd083299dec5ff84cd78081