### PR TITLE
Fix rerun for Streamlit 1.31+

### DIFF
--- a/app.py
+++ b/app.py
@@ -194,7 +194,8 @@ if st.button("Generate story prompts", disabled=generate_disabled):
                 df.at[idx, "story_prompt"] = prompt
     st.session_state.video_df = df
     save_data(df, CSV_FILE)
-    st.experimental_rerun()
+    # Refresh the app to show updated prompts immediately
+    st.rerun()
 
 if st.button("Save changes"):
     save_data(st.session_state.video_df, CSV_FILE)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-streamlit
+streamlit>=1.31
 pandas
 requests


### PR DESCRIPTION
## Summary
- update rerun call to `st.rerun()`
- set minimum Streamlit version in requirements

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686cd2e321948329be8386fd13b0ceaa