### PR TITLE
Add rerun notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ streamlit run app.py
 
 "Generate story prompts" ボタンを押すと、選択された行のプロンプト生成後に
 CSV へ自動保存し、ページをリフレッシュして結果を即座に反映します。
+ページ再読み込み時には "Page reloaded after generating prompts" と表示されます。

--- a/app.py
+++ b/app.py
@@ -116,6 +116,10 @@ def generate_story_prompt(
 
 st.set_page_config(page_title="Video Agent", layout="wide")
 
+# Display notice if the page was refreshed by st.rerun()
+if st.session_state.pop("just_rerun", False):
+    st.info("Page reloaded after generating prompts")
+
 st.title("Streamlit Video Agent")
 
 if "video_df" not in st.session_state:
@@ -195,6 +199,8 @@ if st.button("Generate story prompts", disabled=generate_disabled):
     st.session_state.video_df = df
     save_data(df, CSV_FILE)
     # Refresh the app to show updated prompts immediately
+    # Mark that a rerun is triggered so we can notify the user after reload
+    st.session_state["just_rerun"] = True
     st.rerun()
 
 if st.button("Save changes"):


### PR DESCRIPTION
## Summary
- show an info message when `st.rerun()` triggers
- document rerun message in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686db3834eec8329850066817387ebb8