### PR TITLE
Add rerun message helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,5 @@ streamlit run app.py
 
 "Generate story prompts" ボタンを押すと、選択された行のプロンプト生成後に
 CSV へ自動保存し、ページをリフレッシュして結果を即座に反映します。
-ページ再読み込み時には "Page reloaded after generating prompts" と表示されます。
+アプリから `st.rerun()` が実行された際はリロード後にメッセージが表示され、
+"Page reloaded after generating prompts" などの文言で通知されます。

--- a/app.py
+++ b/app.py
@@ -116,9 +116,17 @@ def generate_story_prompt(
 
 st.set_page_config(page_title="Video Agent", layout="wide")
 
+
+def rerun_with_message(message: str) -> None:
+    """Trigger st.rerun() and show a message after reload."""
+    st.session_state["just_rerun"] = message
+    st.rerun()
+
+
 # Display notice if the page was refreshed by st.rerun()
-if st.session_state.pop("just_rerun", False):
-    st.info("Page reloaded after generating prompts")
+msg = st.session_state.pop("just_rerun", None)
+if msg:
+    st.info(msg)
 
 st.title("Streamlit Video Agent")
 
@@ -200,8 +208,7 @@ if st.button("Generate story prompts", disabled=generate_disabled):
     save_data(df, CSV_FILE)
     # Refresh the app to show updated prompts immediately
     # Mark that a rerun is triggered so we can notify the user after reload
-    st.session_state["just_rerun"] = True
-    st.rerun()
+    rerun_with_message("Page reloaded after generating prompts")
 
 if st.button("Save changes"):
     save_data(st.session_state.video_df, CSV_FILE)


### PR DESCRIPTION
## Summary
- display message after rerun via helper function
- mention rerun notification in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686db5bea6948329bec6162c8c0958fb