### PR TITLE
Add CLI debug mode for LLM communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ pip install -r requirements.txt
 
 ```bash
 streamlit run app.py
+# デバッグ表示を有効化する場合
+streamlit run app.py -- --debug
 ```
 
 実行後、ブラウザで [http://localhost:8501](http://localhost:8501) を開くと UI が表示されます。


### PR DESCRIPTION
## Summary
- support `--debug` option when launching Streamlit
- print request/response details when calling Ollama in debug mode
- document the new option in the README

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e04eed9008329b7edb31038026999