### PR TITLE
Fix missing os import

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import subprocess
 import requests
 import argparse
 import sys
+import os
 
 # Parse CLI arguments passed after `--` when running via Streamlit
 parser = argparse.ArgumentParser(add_help=False)


### PR DESCRIPTION
## Summary
- add `os` import to app

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686e4e295e2c832987ca73cb42e06a86