### PR TITLE
Fix autosave widget handling

### DIFF
--- a/app.py
+++ b/app.py
@@ -524,10 +524,7 @@ if st.button("Generate images", disabled=generate_disabled):
     rerun_with_message("Page reloaded after generating images")
 
 save_col, auto_col = st.columns([1, 1])
-if auto_col.checkbox("Auto-save", value=st.session_state.autosave, key="autosave"):
-    st.session_state.autosave = True
-else:
-    st.session_state.autosave = False
+auto_col.checkbox("Auto-save", value=st.session_state.autosave, key="autosave")
 
 if save_col.button("Save CSV"):
     df = assign_ids(st.session_state.video_df.copy())


### PR DESCRIPTION
## Summary
- fix `autosave` checkbox by removing forbidden state assignment

## Testing
- `python -m py_compile app.py`
- `streamlit run app.py --server.headless true --server.port 8502` *(fails: program ended)*
- `pip install streamlit pandas requests`

------
https://chatgpt.com/codex/tasks/task_e_686f729e314883299c91ce9a518b52b8