### PR TITLE
Add seed column and parameter handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ streamlit run app.py -- --debug
 
 動画リストは **Streamlit Data Editor** を利用しており、`num_rows="dynamic"`
 を指定することで、表から直接行を追加・削除できます。モデルの選択に加え、
-`temperature`、`max_tokens`、`top_p` といった生成パラメータも列として編集
-可能です。
-デフォルト値は `temperature=0.7`、`max_tokens=4096`、`top_p=0.95` です。
+`temperature`、`max_tokens`、`top_p`、`seed` といった生成パラメータも列として
+編集可能です。
+デフォルト値は `temperature=0.7`、`max_tokens=4096`、`top_p=0.95`、`seed=1234`
+です。
 
 "Generate story prompts" ボタンを押すと、選択された行のプロンプト生成後に
 CSV へ自動保存し、ページをリフレッシュして結果を即座に反映します。

--- a/videos.csv
+++ b/videos.csv
@@ -1,2 +1,2 @@
-id,title,synopsis,llm_model,checkpoint,comfy_vae,comfy_lora,temperature,max_tokens,top_p,story_prompt,bgm_prompt,taste_prompt,character_voice,status,needs_approve
-0042,Sample Video,Sample synopsis,phi3:mini,,,,0.7,4096,0.95,Sample story prompt,lofi science,flat comic,cheerful female,sheet,Y
+id,title,synopsis,llm_model,checkpoint,comfy_vae,comfy_lora,temperature,max_tokens,top_p,seed,story_prompt,bgm_prompt,taste_prompt,character_voice,status,needs_approve
+0042,Sample Video,Sample synopsis,phi3:mini,,,,0.7,4096,0.95,1234,Sample story prompt,lofi science,flat comic,cheerful female,sheet,Y


### PR DESCRIPTION
## Summary
- store default image seed in `DEFAULT_SEED`
- include `seed` column when loading CSVs
- expose seed in Streamlit editor
- send seed to `generate_image()`
- document the new column and update sample CSV

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6870921e93848329a2d895cf1078e932