### PR TITLE
Handle blank seed values by generating random seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ streamlit run app.py -- --debug
 `temperature`、`max_tokens`、`top_p`、`seed` といった生成パラメータも列として
 編集可能です。
 デフォルト値は `temperature=0.7`、`max_tokens=4096`、`top_p=0.95`、`seed=1234`
-です。
+です。`seed` 欄を空欄にすると、画像生成時に毎回ランダムなシード値が送られ
+ます。
 
 "Generate story prompts" ボタンを押すと、選択された行のプロンプト生成後に
 CSV へ自動保存し、ページをリフレッシュして結果を即座に反映します。

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ import re
 import json
 import base64
 import time
+import random
 from typing import Optional
 
 # Parse CLI arguments passed after `--` when running via Streamlit
@@ -523,10 +524,11 @@ if st.button("Generate images", disabled=generate_disabled):
         if not prompt:
             st.warning(f"No story prompt for row {row.get('id', idx)}")
             continue
-        seed_val = row.get("seed", DEFAULT_SEED)
-        if pd.isna(seed_val) or seed_val == "":
-            seed_val = DEFAULT_SEED
-        seed_val = int(seed_val)
+        seed_val = row.get("seed", "")
+        if pd.isna(seed_val) or str(seed_val).strip() == "":
+            seed_val = random.randint(0, 2**32 - 1)
+        else:
+            seed_val = int(seed_val)
         img_bytes = generate_image(prompt, checkpoint, vae, seed_val, debug=DEBUG_MODE)
         title = row.get("title", "")
         folder = os.path.join("vids", f"{row.get('id', idx)}_{slugify(title)}", "panels")


### PR DESCRIPTION
## Summary
- generate a random seed when the seed column is empty
- document random seed behaviour

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68709b60ca5c83298bbb9b2f0998998c