### PR TITLE
Update seed handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ streamlit run app.py -- --debug
 編集可能です。
 デフォルト値は `temperature=0.7`、`max_tokens=4096`、`top_p=0.95`、`seed=1234`、`batch_count=1`
 です。`seed` 欄を空欄にすると、画像生成時に毎回ランダムなシード値が送られ
-ます。`batch_count` を空欄にすると 1 枚だけ生成します。
+ます。`-1` を入力した場合はその値をそのまま API へ渡し、ComfyUI 側でランダム
+シードが採用されます。`batch_count` を空欄にすると 1 枚だけ生成します。
 
 "Generate story prompts" ボタンを押すと、選択された行のプロンプト生成後に
 CSV へ自動保存し、ページをリフレッシュして結果を即座に反映します。

--- a/app.py
+++ b/app.py
@@ -542,6 +542,7 @@ if st.button("Generate images", disabled=generate_disabled):
             continue
         seed_val = row.get("seed", "")
         if pd.isna(seed_val) or str(seed_val).strip() == "":
+            # Empty -> generate a random seed on our side
             seed_val = random.randint(0, 2**32 - 1)
         else:
             seed_val = int(seed_val)
@@ -556,7 +557,11 @@ if st.button("Generate images", disabled=generate_disabled):
         folder = os.path.join("vids", f"{row.get('id', idx)}_{slugify(title)}", "panels")
 
         for b in range(batch_count):
-            current_seed = seed_val + b if batch_count > 1 else seed_val
+            if seed_val == -1:
+                # -1 is passed through so ComfyUI handles randomization
+                current_seed = -1
+            else:
+                current_seed = seed_val + b if batch_count > 1 else seed_val
             img_bytes = generate_image(prompt, checkpoint, vae, current_seed, debug=DEBUG_MODE)
             if img_bytes:
                 os.makedirs(folder, exist_ok=True)


### PR DESCRIPTION
## Summary
- avoid incrementing when seed is `-1`
- explain `-1` seed usage in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6873539db40c8329911fb86d14909a57