### PR TITLE
Fix sequential ID assignment and add tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -107,25 +107,20 @@ def unique_path(path: str) -> str:
 def assign_ids(df: pd.DataFrame) -> pd.DataFrame:
     """Assign zero-padded numeric IDs to rows missing an ID."""
     used_ids = set()
-    next_id = 1
-    for val in df.get("id", []):
-        if pd.isna(val):
-            continue
-        sval = str(val)
-        if sval.isdigit():
+    ids = df.get("id", pd.Series(dtype=str))
+
+    for idx, val in ids.items():
+        sval = str(val).strip()
+        if sval.isdigit() and int(sval) not in used_ids:
             num = int(sval)
             used_ids.add(num)
-            if num >= next_id:
-                next_id = num + 1
-
-    for idx, val in df.get("id", pd.Series(dtype=str)).items():
-        sval = str(val)
-        if sval == "" or not sval.isdigit():
-            while next_id in used_ids:
-                next_id += 1
-            df.at[idx, "id"] = f"{next_id:04d}"
-            used_ids.add(next_id)
-            next_id += 1
+            df.at[idx, "id"] = f"{num:04d}"
+        else:
+            new_id = 1
+            while new_id in used_ids:
+                new_id += 1
+            df.at[idx, "id"] = f"{new_id:04d}"
+            used_ids.add(new_id)
     return df
 
 

--- a/test_assign_ids.py
+++ b/test_assign_ids.py
@@ -1,0 +1,18 @@
+import pandas as pd
+from app import assign_ids
+
+
+def test_assign_ids_fill_gap():
+    df = pd.DataFrame({"id": ["0001", "0003"], "title": ["A", "C"]})
+    new_row = pd.DataFrame([{"id": "", "title": "B"}])
+    df = pd.concat([df.iloc[:1], new_row, df.iloc[1:]], ignore_index=True)
+    result = assign_ids(df)
+    assert result.loc[1, "id"] == "0002"
+
+
+def test_assign_ids_append():
+    df = pd.DataFrame({"id": ["0001", "0002"], "title": ["A", "B"]})
+    df = pd.concat([df, pd.DataFrame([{"id": "", "title": "C"}])], ignore_index=True)
+    result = assign_ids(df)
+    assert result.loc[2, "id"] == "0003"
+


### PR DESCRIPTION
## Summary
- fix the ID assignment logic so new rows get the lowest available number
- add regression tests for ID assignment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68749bdaa1d8832997a086665c94ea40