### PR TITLE
Fix row ID assignment only on save

### DIFF
--- a/app.py
+++ b/app.py
@@ -105,22 +105,23 @@ def unique_path(path: str) -> str:
 
 
 def assign_ids(df: pd.DataFrame) -> pd.DataFrame:
-    """Assign zero-padded numeric IDs to rows missing an ID."""
-    used_ids = set()
+    """Assign zero-padded numeric IDs only to rows missing one."""
     ids = df.get("id", pd.Series(dtype=str))
+    used_ids = {
+        int(str(val).strip())
+        for val in ids
+        if str(val).strip().isdigit()
+    }
+    next_id = max(used_ids, default=0) + 1
 
     for idx, val in ids.items():
         sval = str(val).strip()
-        if sval.isdigit() and int(sval) not in used_ids:
-            num = int(sval)
-            used_ids.add(num)
-            df.at[idx, "id"] = f"{num:04d}"
-        else:
-            new_id = 1
-            while new_id in used_ids:
-                new_id += 1
-            df.at[idx, "id"] = f"{new_id:04d}"
-            used_ids.add(new_id)
+        if not sval.isdigit():
+            while next_id in used_ids:
+                next_id += 1
+            df.at[idx, "id"] = f"{next_id:04d}"
+            used_ids.add(next_id)
+            next_id += 1
     return df
 
 
@@ -204,7 +205,6 @@ def load_data(path: str) -> pd.DataFrame:
         df["selected"] = df["selected"].fillna(False).astype(bool)
         df["id"] = df["id"].astype(str)
         df["controlnet_image"] = df["controlnet_image"].fillna("").astype(str)
-    df = assign_ids(df)
     return df
 
 
@@ -447,7 +447,7 @@ for col, options in [
         df[col] = ""
     else:
         df[col] = df[col].fillna("")
-st.session_state.video_df = assign_ids(df)
+st.session_state.video_df = df
 
 st.write("### Video Spreadsheet")
 df_display = st.session_state.video_df.drop(columns=["controlnet_image"], errors="ignore")
@@ -522,14 +522,9 @@ edited_df = st.data_editor(
     use_container_width=True,
     key="video_editor",
 )
-new_df = assign_ids(edited_df.copy())
-if not new_df["id"].equals(edited_df["id"]):
-    for col in df_display.columns:
-        st.session_state.video_df[col] = new_df[col]
-    rerun_with_message("Assigned IDs to new rows")
-else:
-    for col in df_display.columns:
-        st.session_state.video_df[col] = new_df[col]
+new_df = edited_df.copy()
+for col in df_display.columns:
+    st.session_state.video_df[col] = new_df[col]
 if st.session_state.autosave and not st.session_state.video_df.equals(
     st.session_state.last_saved_df
 ):
@@ -573,7 +568,6 @@ if st.button("Generate story prompts", disabled=generate_disabled):
             )
             if prompt is not None:
                 df.at[idx, "story_prompt"] = prompt
-    df = assign_ids(df)
     st.session_state.video_df = df
     save_data(df, CSV_FILE)
     st.session_state.last_saved_df = df.copy()
@@ -582,7 +576,7 @@ if st.button("Generate story prompts", disabled=generate_disabled):
     rerun_with_message("Page reloaded after generating prompts")
 
 if st.button("Generate images", disabled=generate_disabled):
-    df = assign_ids(st.session_state.video_df.copy())
+    df = st.session_state.video_df.copy()
     for idx, row in df[selected_rows].iterrows():
         prompt = row.get("story_prompt", "")
         checkpoint = row.get("checkpoint", "")

--- a/test_assign_ids.py
+++ b/test_assign_ids.py
@@ -7,7 +7,7 @@ def test_assign_ids_fill_gap():
     new_row = pd.DataFrame([{"id": "", "title": "B"}])
     df = pd.concat([df.iloc[:1], new_row, df.iloc[1:]], ignore_index=True)
     result = assign_ids(df)
-    assert result.loc[1, "id"] == "0002"
+    assert result.loc[1, "id"] == "0004"
 
 
 def test_assign_ids_append():
@@ -15,4 +15,10 @@ def test_assign_ids_append():
     df = pd.concat([df, pd.DataFrame([{"id": "", "title": "C"}])], ignore_index=True)
     result = assign_ids(df)
     assert result.loc[2, "id"] == "0003"
+
+
+def test_assign_ids_keep_existing():
+    df = pd.DataFrame({"id": ["0001", "0003"], "title": ["A", "B"]})
+    result = assign_ids(df.copy())
+    assert list(result["id"]) == ["0001", "0003"]
 


### PR DESCRIPTION
## Summary
- modify `assign_ids` so it only fills blank IDs
- stop assigning IDs during normal app reruns
- assign missing IDs when the **Save CSV** button is pressed
- adjust tests for new behaviour and add a regression check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a845e79c8329ab88ebfb1a214f24