### PR TITLE
Allow editing of ID in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ streamlit run app.py -- --debug
 動画リストは **Streamlit Data Editor** を利用しており、`num_rows="dynamic"`
 を指定することで、表から直接行を追加・削除できます。モデルの選択に加え、
 `temperature`、`max_tokens`、`top_p`、`seed`、`batch_count`、`width`、`height` といった生成パラメータも列として
-編集可能です。
+編集可能です。`id` 列も編集でき、空欄のまま保存すると自動的に連番が割り当てられます。
 デフォルト値は `temperature=0.7`、`max_tokens=4096`、`top_p=0.95`、`seed=1234`、`batch_count=1`、`width=1024`、`height=1024`
 です。`seed` 欄を空欄にすると、画像生成時に毎回ランダムなシード値が送られ
 ます。`-1` を入力した場合はその値をそのまま API へ渡し、ComfyUI 側でランダム

--- a/app.py
+++ b/app.py
@@ -456,7 +456,7 @@ edited_df = st.data_editor(
     df_display,
     column_config={
         "selected": st.column_config.CheckboxColumn("Select"),
-        "id": st.column_config.TextColumn("ID", disabled=True),
+        "id": st.column_config.TextColumn("ID"),
         "llm_model": st.column_config.SelectboxColumn(
             "Model",
             options=st.session_state.models,


### PR DESCRIPTION
## Summary
- make the ID column editable in the data editor
- document that the ID column can be modified

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874c1b8984883298e0349ba54bf0167