### PR TITLE
Move Ollama helpers to module

### DIFF
--- a/movie_agent/ollama.py
+++ b/movie_agent/ollama.py
@@ -1,0 +1,84 @@
+import argparse
+import subprocess
+import requests
+import streamlit as st
+
+# Parse optional debug flag when imported
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+args, _ = parser.parse_known_args()
+DEBUG_MODE = args.debug
+if DEBUG_MODE:
+    print("[DEBUG] Debug mode enabled")
+
+
+def list_ollama_models(debug: bool | None = None) -> list[str]:
+    """Return available Ollama models."""
+    if debug is None:
+        debug = DEBUG_MODE
+    try:
+        result = subprocess.run(
+            ["ollama", "list"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=True,
+        )
+        if debug:
+            print("[DEBUG] ollama list stdout:", result.stdout)
+    except Exception as e:
+        if debug:
+            print("[DEBUG] ollama list error:", e)
+        return ["phi3:mini"]
+    lines = result.stdout.strip().splitlines()
+    models = []
+    for line in lines[1:]:
+        parts = line.split()
+        if parts:
+            models.append(parts[0])
+    return models or ["phi3:mini"]
+
+
+def generate_story_prompt(
+    synopsis: str,
+    model: str,
+    temperature: float,
+    max_tokens: int,
+    top_p: float,
+    debug: bool | None = None,
+) -> str | None:
+    """Generate a story prompt using the local Ollama API."""
+    if debug is None:
+        debug = DEBUG_MODE
+    prompt = f"Generate a short story based on this synopsis:\n{synopsis}\n"
+    url = "http://localhost:11434/api/generate"
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "temperature": temperature,
+        "num_predict": max_tokens,
+        "top_p": top_p,
+        "stream": False,
+    }
+    if debug:
+        print("[DEBUG] Request payload:", payload)
+    try:
+        res = requests.post(url, json=payload, timeout=60)
+        if debug:
+            print("[DEBUG] Response status:", res.status_code)
+            print("[DEBUG] Raw response:", res.text)
+        res.raise_for_status()
+        data = res.json()
+        if debug:
+            print("[DEBUG] Parsed response:", data)
+        return data.get("response", "").strip()
+    except requests.exceptions.RequestException as e:
+        st.error(f"Ollama API error: {e}")
+    except ValueError as e:
+        st.error(f"Invalid response from Ollama: {e}")
+    except Exception as e:
+        st.error(f"Error: {e}")
+    return None
+
+__all__ = ["list_ollama_models", "generate_story_prompt", "DEBUG_MODE"]

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import sys
+import subprocess
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from movie_agent.ollama import list_ollama_models, generate_story_prompt
+
+
+def test_list_ollama_models(monkeypatch):
+    class Dummy:
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    def fake_run(*args, **kwargs):
+        return Dummy("NAME\tMODIFIED\tSIZE\nphi3:mini 2024-01-01 1GB\nllama2:7b 2024-01-02 2GB\n")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    models = list_ollama_models()
+    assert models == ["phi3:mini", "llama2:7b"]
+
+
+def test_generate_story_prompt(monkeypatch):
+    class FakeResponse:
+        status_code = 200
+        text = '{"response": "Once upon a time"}'
+
+        def json(self):
+            return {"response": "Once upon a time"}
+
+        def raise_for_status(self):
+            pass
+
+    def fake_post(*args, **kwargs):
+        return FakeResponse()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    result = generate_story_prompt("A synopsis", "phi3:mini", 0.7, 10, 0.9)
+    assert result == "Once upon a time"
+


### PR DESCRIPTION
## Summary
- add `ollama.py` module with Ollama helper functions
- update `app.py` to use the new module
- support debug flag inside `ollama.py`
- test both helpers with mocked subprocess and requests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874f7dbd0008329b870ab88a6ae9fbe