### PR TITLE
Add simple entrypoint module

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ pip install -r requirements.txt
 ## UI の起動方法
 
 ```bash
-streamlit run movie_agent/gui.py
+python -m movie_agent.main
 # デバッグ表示を有効化する場合
-streamlit run movie_agent/gui.py -- --debug
+python -m movie_agent.main --debug
 ```
 
 実行後、ブラウザで [http://localhost:8501](http://localhost:8501) を開くと UI が表示されます。

--- a/movie_agent/main.py
+++ b/movie_agent/main.py
@@ -1,0 +1,12 @@
+"""Entry point for running the Streamlit GUI."""
+
+from . import gui
+
+
+def main() -> None:
+    """Launch the GUI."""
+    gui.main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expose a new `movie_agent.main` module that forwards to `gui.main`
- document launching the app with `python -m movie_agent.main`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874fff1c9348329aeb1e217e4906726