### PR TITLE
Fix Data Editor row persistence

### DIFF
--- a/movie_agent/gui.py
+++ b/movie_agent/gui.py
@@ -163,8 +163,11 @@ def main() -> None:
         key="video_editor",
     )
     new_df = edited_df.copy()
-    for col in df_display.columns:
-        st.session_state.video_df[col] = new_df[col]
+    if "controlnet_image" in st.session_state.video_df.columns:
+        new_df["controlnet_image"] = st.session_state.video_df[
+            "controlnet_image"
+        ].reindex(new_df.index, fill_value="")
+    st.session_state.video_df = new_df[st.session_state.video_df.columns]
     if st.session_state.autosave and not st.session_state.video_df.equals(
         st.session_state.last_saved_df
     ):


### PR DESCRIPTION
## Summary
- ensure new rows from `st.data_editor` persist in saved CSV

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875a4efa51483298fe15ff009a5c7b5