### PR TITLE
Add CFG and steps columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ streamlit run movie_agent/app.py -- --debug
 
 動画リストは **Streamlit Data Editor** を利用しており、`num_rows="dynamic"`
 を指定することで、表から直接行を追加・削除できます。モデルの選択に加え、
-`temperature`、`max_tokens`、`top_p`、`seed`、`batch_count`、`width`、`height` といった生成パラメータも列として
+`temperature`、`max_tokens`、`top_p`、`cfg`、`steps`、`seed`、`batch_count`、`width`、`height` といった生成パラメータも列として
 編集可能です。
-デフォルト値は `temperature=0.7`、`max_tokens=4096`、`top_p=0.95`、`seed=1234`、`batch_count=1`、`width=1024`、`height=1024`
+デフォルト値は `temperature=0.7`、`max_tokens=4096`、`top_p=0.95`、`cfg=7`、`steps=28`、`seed=1234`、`batch_count=1`、`width=1024`、`height=1024`
 です。`seed` 欄を空欄にすると、画像生成時に毎回ランダムなシード値が送られ
 ます。`-1` を入力した場合はその値をそのまま API へ渡し、ComfyUI 側でランダム
 シードが採用されます。`batch_count` を空欄にすると 1 枚だけ生成します。

--- a/movie_agent/comfyui.py
+++ b/movie_agent/comfyui.py
@@ -105,6 +105,8 @@ def generate_image(
     seed: int,
     width: int = DEFAULT_WIDTH,
     height: int = DEFAULT_HEIGHT,
+    cfg: float = DEFAULT_CFG,
+    steps: int = DEFAULT_STEPS,
     control_image: str | None = None,
     debug: bool = False,
 ) -> Optional[bytes]:
@@ -118,6 +120,8 @@ def generate_image(
     if vae:
         workflow["4"]["inputs"]["vae_name"] = vae
     workflow["3"]["inputs"]["seed"] = seed
+    workflow["3"]["inputs"]["cfg"] = cfg
+    workflow["3"]["inputs"]["steps"] = steps
     workflow["5"]["inputs"]["width"] = width
     workflow["5"]["inputs"]["height"] = height
 

--- a/movie_agent/csv_manager.py
+++ b/movie_agent/csv_manager.py
@@ -2,6 +2,8 @@ import os
 import re
 import pandas as pd
 
+from .comfyui import DEFAULT_CFG, DEFAULT_STEPS
+
 # Default generation parameters used when initializing a new CSV
 DEFAULT_MODEL = "phi3:mini"
 DEFAULT_TEMPERATURE = 0.7
@@ -48,6 +50,8 @@ def load_data(path: str) -> pd.DataFrame:
         "temperature",
         "max_tokens",
         "top_p",
+        "cfg",
+        "steps",
         "seed",
         "batch_count",
         "width",
@@ -73,6 +77,8 @@ def load_data(path: str) -> pd.DataFrame:
         df["temperature"] = DEFAULT_TEMPERATURE
         df["max_tokens"] = DEFAULT_MAX_TOKENS
         df["top_p"] = DEFAULT_TOP_P
+        df["cfg"] = DEFAULT_CFG
+        df["steps"] = DEFAULT_STEPS
         df["seed"] = DEFAULT_SEED
         df["batch_count"] = 1
         df["width"] = DEFAULT_WIDTH
@@ -101,6 +107,10 @@ def load_data(path: str) -> pd.DataFrame:
             df["max_tokens"] = DEFAULT_MAX_TOKENS
         if "top_p" in missing_cols:
             df["top_p"] = DEFAULT_TOP_P
+        if "cfg" in missing_cols:
+            df["cfg"] = DEFAULT_CFG
+        if "steps" in missing_cols:
+            df["steps"] = DEFAULT_STEPS
         if "seed" in missing_cols:
             df["seed"] = DEFAULT_SEED
         if "batch_count" in missing_cols:

--- a/movie_agent/gui.py
+++ b/movie_agent/gui.py
@@ -4,7 +4,12 @@ import pandas as pd
 import os
 import random
 from pathlib import Path
-from .comfyui import list_comfy_models, generate_image
+from .comfyui import (
+    list_comfy_models,
+    generate_image,
+    DEFAULT_CFG,
+    DEFAULT_STEPS,
+)
 from .ollama import list_ollama_models, generate_story_prompt, DEBUG_MODE
 from .csv_manager import (
     load_data,
@@ -136,6 +141,17 @@ def main() -> None:
                 min_value=0.0,
                 max_value=1.0,
             ),
+            "cfg": st.column_config.NumberColumn(
+                "CFG",
+                format="%.1f",
+                step=0.5,
+                min_value=0.0,
+            ),
+            "steps": st.column_config.NumberColumn(
+                "Steps",
+                min_value=1,
+                step=1,
+            ),
             "seed": st.column_config.NumberColumn(
                 "Seed",
                 step=1,
@@ -258,6 +274,16 @@ def main() -> None:
                 height = DEFAULT_HEIGHT
             height = int(height)
 
+            cfg_val = row.get("cfg", DEFAULT_CFG)
+            if pd.isna(cfg_val) or str(cfg_val).strip() == "":
+                cfg_val = DEFAULT_CFG
+            cfg_val = float(cfg_val)
+
+            steps_val = row.get("steps", DEFAULT_STEPS)
+            if pd.isna(steps_val) or str(steps_val).strip() == "":
+                steps_val = DEFAULT_STEPS
+            steps_val = int(steps_val)
+
             for b in range(batch_count):
                 if seed_val == -1:
                     # -1 is passed through so ComfyUI handles randomization
@@ -273,6 +299,8 @@ def main() -> None:
                     current_seed,
                     width=width,
                     height=height,
+                    cfg=cfg_val,
+                    steps=steps_val,
                     control_image=control_img if control_img else None,
                     debug=DEBUG_MODE,
                 )

--- a/tests/test_comfyui.py
+++ b/tests/test_comfyui.py
@@ -71,5 +71,5 @@ def test_generate_image(monkeypatch):
     monkeypatch.setattr(requests, "get", fake_get)
     monkeypatch.setattr(time, "sleep", lambda x: None)
 
-    data = generate_image("p", "ckpt", "", 1)
+    data = generate_image("p", "ckpt", "", 1, cfg=5, steps=20)
     assert data == b"image-bytes"

--- a/tests/test_csv_manager.py
+++ b/tests/test_csv_manager.py
@@ -8,6 +8,8 @@ from movie_agent.csv_manager import (
     DEFAULT_MODEL,
     DEFAULT_MAX_TOKENS,
     DEFAULT_TEMPERATURE,
+    DEFAULT_CFG,
+    DEFAULT_STEPS,
 )
 
 
@@ -52,5 +54,7 @@ def test_load_data_defaults_existing_file(tmp_path):
     # other missing columns populated with defaults
     assert loaded.loc[0, "llm_model"] == DEFAULT_MODEL
     assert loaded.loc[0, "max_tokens"] == DEFAULT_MAX_TOKENS
+    assert loaded.loc[0, "cfg"] == DEFAULT_CFG
+    assert loaded.loc[0, "steps"] == DEFAULT_STEPS
     # selected column should default to False
     assert bool(loaded.loc[0, "selected"]) is False

--- a/videos.csv
+++ b/videos.csv
@@ -1,2 +1,2 @@
-id,title,synopsis,llm_model,checkpoint,comfy_vae,comfy_lora,temperature,max_tokens,top_p,seed,batch_count,width,height,story_prompt,bgm_prompt,taste_prompt,character_voice,status,needs_approve,controlnet_image
-0042,Sample Video,Sample synopsis,phi3:mini,,,,0.7,4096,0.95,1234,1,1024,1024,Sample story prompt,lofi science,flat comic,cheerful female,sheet,Y,
+id,title,synopsis,llm_model,checkpoint,comfy_vae,comfy_lora,temperature,max_tokens,top_p,cfg,steps,seed,batch_count,width,height,story_prompt,bgm_prompt,taste_prompt,character_voice,status,needs_approve,controlnet_image
+0042,Sample Video,Sample synopsis,phi3:mini,,,,0.7,4096,0.95,7,28,1234,1,1024,1024,Sample story prompt,lofi science,flat comic,cheerful female,sheet,Y,


### PR DESCRIPTION
## Summary
- allow customizing CFG and step count per row
- propagate these params to ComfyUI requests
- show new columns in the Streamlit editor
- document the defaults
- adjust tests

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875e7af2a7083298ae482a3322f821d