### PR TITLE
Add framepack mock test and CSV regression checks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path so movie_agent can be imported
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/tests/test_csv_manager.py
+++ b/tests/test_csv_manager.py
@@ -24,6 +24,8 @@ def test_load_data_missing(tmp_path):
     assert "movie_prompt" in df.columns
     assert "video_length" in df.columns
     assert "fps" in df.columns
+    assert "batch_count" in df.columns
+    assert "controlnet_image" in df.columns
 
 
 def test_save_data(tmp_path):
@@ -68,3 +70,5 @@ def test_load_data_defaults_existing_file(tmp_path):
     assert loaded.loc[0, "video_length"] == DEFAULT_VIDEO_LENGTH
     assert loaded.loc[0, "fps"] == DEFAULT_FPS
     assert loaded.loc[0, "movie_prompt"] == ""
+    assert loaded.loc[0, "batch_count"] == 1
+    assert loaded.loc[0, "controlnet_image"] == ""

--- a/tests/test_framepack.py
+++ b/tests/test_framepack.py
@@ -1,0 +1,25 @@
+import movie_agent.framepack as framepack
+
+
+def test_generate_video(monkeypatch):
+    calls = {}
+
+    class DummyClient:
+        def __init__(self, url):
+            calls['url'] = url
+
+        def predict(self, frames_dir, fps, output, api_name=None):
+            calls['args'] = (frames_dir, fps, output)
+            calls['api_name'] = api_name
+            return 'result-data'
+
+    monkeypatch.setattr(framepack, 'Client', DummyClient)
+    monkeypatch.setattr(framepack, 'FRAMEPACK_HOST', '1.2.3.4')
+    monkeypatch.setattr(framepack, 'FRAMEPACK_PORT', '1234')
+
+    result = framepack.generate_video('frames', fps=30, output='out.mp4')
+
+    assert result == 'result-data'
+    assert calls['url'] == 'http://1.2.3.4:1234/'
+    assert calls['args'] == ('frames', 30, 'out.mp4')
+    assert calls['api_name'] == '/predict'


### PR DESCRIPTION
## Summary
- add conftest to ensure `movie_agent` is importable during tests
- create tests for `generate_video` and mock `gradio_client.Client`
- check additional default columns in CSV tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876f197f5b48329bbebb60d3a302293