### PR TITLE
Add video options to CSV and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ streamlit run movie_agent/app.py -- --debug
 
 動画リストは **Streamlit Data Editor** を利用しており、`num_rows="dynamic"`
 を指定することで、表から直接行を追加・削除できます。モデルの選択に加え、
-`temperature`、`max_tokens`、`top_p`、`cfg`、`steps`、`seed`、`batch_count`、`width`、`height` といった生成パラメータも列として
+`temperature`、`max_tokens`、`top_p`、`cfg`、`steps`、`seed`、`batch_count`、`width`、`height` といった生成パラメータや、動画用の `movie_prompt`、`video_length`、`fps` も列として
 編集可能です。
-デフォルト値は `temperature=0.7`、`max_tokens=4096`、`top_p=0.95`、`cfg=7`、`steps=28`、`seed=1234`、`batch_count=1`、`width=1024`、`height=1024`
+デフォルト値は `temperature=0.7`、`max_tokens=4096`、`top_p=0.95`、`cfg=7`、`steps=28`、`seed=1234`、`batch_count=1`、`width=1024`、`height=1024`、`video_length=0`、`fps=24`
 です。`seed` 欄を空欄にすると、画像生成時に毎回ランダムなシード値が送られ
 ます。`-1` を入力した場合はその値をそのまま API へ渡し、ComfyUI 側でランダム
 シードが採用されます。`batch_count` を空欄にすると 1 枚だけ生成します。
@@ -73,3 +73,4 @@ python demo_gradio.py --port 8001
 Streamlit UI でフレーム画像を用意した行を選択し、画面下部の **Generate videos** ボ
 タンを押すと `vids/<id>_<slug>/video_raw.mp4` が生成されます。フレームパックサーバ
 ーが起動している必要があります。
+ここで `fps` 列の値がフレームパックへ渡され、指定されたフレームレートで動画が生成されます。`movie_prompt` と `video_length` は後段の編集工程で利用される予定です。

--- a/videos.csv
+++ b/videos.csv
@@ -1,2 +1,2 @@
-id,title,synopsis,llm_model,checkpoint,comfy_vae,comfy_lora,temperature,max_tokens,top_p,cfg,steps,seed,batch_count,width,height,story_prompt,bgm_prompt,taste_prompt,character_voice,status,needs_approve,controlnet_image
-0042,Sample Video,Sample synopsis,phi3:mini,,,,0.7,4096,0.95,7,28,1234,1,1024,1024,Sample story prompt,lofi science,flat comic,cheerful female,sheet,Y,
+id,title,synopsis,llm_model,checkpoint,comfy_vae,comfy_lora,temperature,max_tokens,top_p,cfg,steps,seed,batch_count,width,height,story_prompt,bgm_prompt,taste_prompt,character_voice,movie_prompt,video_length,fps,status,needs_approve,controlnet_image
+0042,Sample Video,Sample synopsis,phi3:mini,,,,0.7,4096,0.95,7,28,1234,1,1024,1024,Sample story prompt,lofi science,flat comic,cheerful female,,0,24,sheet,Y,


### PR DESCRIPTION
## Summary
- extend `videos.csv` with `movie_prompt`, `video_length` and `fps`
- mention the new fields in README with their defaults
- note that `fps` is used during the *Generate videos* step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876f6eed7e483298f23e64eb84c2192