### PR TITLE
Update framepack api constant

### DIFF
--- a/movie_agent/framepack.py
+++ b/movie_agent/framepack.py
@@ -5,6 +5,7 @@ from gradio_client import Client
 
 FRAMEPACK_HOST = os.getenv("FRAMEPACK_HOST", "127.0.0.1")
 FRAMEPACK_PORT = os.getenv("FRAMEPACK_PORT", "8001")
+FRAMEPACK_API_NAME = os.getenv("FRAMEPACK_API_NAME", "/validate_and_process")
 
 
 def generate_video(
@@ -17,7 +18,7 @@ def generate_video(
     url = f"http://{FRAMEPACK_HOST}:{FRAMEPACK_PORT}/"
     client = Client(url)
     try:
-        result = client.predict(frames_dir, fps, output, api_name="/predict")
+        result = client.predict(frames_dir, fps, output, api_name=FRAMEPACK_API_NAME)
         if debug:
             print("[DEBUG] framepack response:", result)
         return result
@@ -27,4 +28,9 @@ def generate_video(
         return None
 
 
-__all__ = ["generate_video", "FRAMEPACK_HOST", "FRAMEPACK_PORT"]
+__all__ = [
+    "generate_video",
+    "FRAMEPACK_HOST",
+    "FRAMEPACK_PORT",
+    "FRAMEPACK_API_NAME",
+]

--- a/tests/test_framepack.py
+++ b/tests/test_framepack.py
@@ -16,10 +16,11 @@ def test_generate_video(monkeypatch):
     monkeypatch.setattr(framepack, 'Client', DummyClient)
     monkeypatch.setattr(framepack, 'FRAMEPACK_HOST', '1.2.3.4')
     monkeypatch.setattr(framepack, 'FRAMEPACK_PORT', '1234')
+    monkeypatch.setattr(framepack, 'FRAMEPACK_API_NAME', '/api')
 
     result = framepack.generate_video('frames', fps=30, output='out.mp4')
 
     assert result == 'result-data'
     assert calls['url'] == 'http://1.2.3.4:1234/'
     assert calls['args'] == ('frames', 30, 'out.mp4')
-    assert calls['api_name'] == '/predict'
+    assert calls['api_name'] == '/api'


### PR DESCRIPTION
## Summary
- make framepack API endpoint configurable with `FRAMEPACK_API_NAME`
- use the constant when calling `Client.predict`
- export the new constant
- update tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877237041048329823c664a003c34bf