### PR TITLE
Update framepack wrapper

### DIFF
--- a/movie_agent/framepack.py
+++ b/movie_agent/framepack.py
@@ -1,7 +1,7 @@
 import os
 from typing import Optional
 
-from gradio_client import Client
+from gradio_client import Client, handle_file
 
 FRAMEPACK_HOST = os.getenv("FRAMEPACK_HOST", "127.0.0.1")
 FRAMEPACK_PORT = os.getenv("FRAMEPACK_PORT", "8001")
@@ -9,16 +9,44 @@ FRAMEPACK_API_NAME = os.getenv("FRAMEPACK_API_NAME", "/validate_and_process")
 
 
 def generate_video(
-    frames_dir: str,
-    fps: int = 24,
-    output: str = "video.mp4",
+    image: str,
+    prompt: str,
+    seed: int,
+    video_length: float,
+    latent_window_size: int,
+    steps: int,
+    cfg: float,
+    gs: float,
+    rs: float,
+    gpu_memory_preservation: float,
+    use_teacache: bool,
+    mp4_crf: int,
     debug: bool = False,
 ) -> Optional[str]:
-    """Generate a video from ``frames_dir`` using the local framepack server."""
+    """Generate a video using the local framepack server."""
+
     url = f"http://{FRAMEPACK_HOST}:{FRAMEPACK_PORT}/"
     client = Client(url)
+
+    img_param = handle_file(image)
+
     try:
-        result = client.predict(frames_dir, fps, output, api_name=FRAMEPACK_API_NAME)
+        result = client.predict(
+            img_param,
+            prompt,
+            "",  # n_prompt
+            seed,
+            video_length,
+            latent_window_size,
+            steps,
+            cfg,
+            gs,
+            rs,
+            gpu_memory_preservation,
+            use_teacache,
+            mp4_crf,
+            api_name=FRAMEPACK_API_NAME,
+        )
         if debug:
             print("[DEBUG] framepack response:", result)
         return result

--- a/tests/test_framepack.py
+++ b/tests/test_framepack.py
@@ -8,19 +8,52 @@ def test_generate_video(monkeypatch):
         def __init__(self, url):
             calls['url'] = url
 
-        def predict(self, frames_dir, fps, output, api_name=None):
-            calls['args'] = (frames_dir, fps, output)
+        def predict(self, *args, api_name=None):
+            calls['args'] = args
             calls['api_name'] = api_name
             return 'result-data'
 
+    def fake_handle_file(path):
+        calls['handled'] = path
+        return {'path': path}
+
     monkeypatch.setattr(framepack, 'Client', DummyClient)
+    monkeypatch.setattr(framepack, 'handle_file', fake_handle_file)
     monkeypatch.setattr(framepack, 'FRAMEPACK_HOST', '1.2.3.4')
     monkeypatch.setattr(framepack, 'FRAMEPACK_PORT', '1234')
     monkeypatch.setattr(framepack, 'FRAMEPACK_API_NAME', '/validate_and_process')
 
-    result = framepack.generate_video('frames', fps=30, output='out.mp4')
+    result = framepack.generate_video(
+        'start.png',
+        prompt='p',
+        seed=1,
+        video_length=2,
+        latent_window_size=3,
+        steps=4,
+        cfg=5.0,
+        gs=6.0,
+        rs=7.0,
+        gpu_memory_preservation=8.0,
+        use_teacache=True,
+        mp4_crf=9,
+    )
 
     assert result == 'result-data'
     assert calls['url'] == 'http://1.2.3.4:1234/'
-    assert calls['args'] == ('frames', 30, 'out.mp4')
+    assert calls['handled'] == 'start.png'
+    assert calls['args'] == (
+        {'path': 'start.png'},
+        'p',
+        '',
+        1,
+        2,
+        3,
+        4,
+        5.0,
+        6.0,
+        7.0,
+        8.0,
+        True,
+        9,
+    )
     assert calls['api_name'] == framepack.FRAMEPACK_API_NAME


### PR DESCRIPTION
## Summary
- extend `generate_video` to use FramePack's generator API
- handle image files via `handle_file`
- adapt unit tests to validate parameter ordering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68772d05b0d083298633ae00eea233ec