### PR TITLE
Improve framepack debug logs

### DIFF
--- a/movie_agent/framepack.py
+++ b/movie_agent/framepack.py
@@ -40,6 +40,7 @@ def generate_video(
             "[DEBUG] framepack params:",
             {
                 "image": image,
+                "prompt": prompt,
                 "seed": seed,
                 "video_length": video_length,
                 "latent_window_size": latent_window_size,
@@ -48,6 +49,7 @@ def generate_video(
                 "gs": gs,
                 "rs": rs,
                 "gpu_memory_preservation": gpu_memory_preservation,
+                "use_teacache": use_teacache,
                 "mp4_crf": mp4_crf,
             },
         )

--- a/tests/test_framepack.py
+++ b/tests/test_framepack.py
@@ -103,4 +103,6 @@ def test_generate_video_debug(monkeypatch, capsys):
     assert out[0] == '[DEBUG] framepack url: http://1.2.3.4:1234//validate_and_process'
     assert out[1].startswith('[DEBUG] framepack params:')
     assert "'mp4_crf': 9" in out[1]
+    assert "'prompt': 'p'" in out[1]
+    assert "'use_teacache': True" in out[1]
     assert out[2] == '[DEBUG] framepack response: result-data'


### PR DESCRIPTION
## Summary
- log all parameters in `framepack.generate_video` when debug mode is enabled
- check for prompt and use_teacache parameters in debug test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68773d5b00c8832991e6a2ad96f02a36