### PR TITLE
Fix NameError when generating videos

### DIFF
--- a/movie_agent/gui.py
+++ b/movie_agent/gui.py
@@ -22,6 +22,7 @@ from .csv_manager import (
     DEFAULT_WIDTH,
     DEFAULT_HEIGHT,
     DEFAULT_FPS,
+    DEFAULT_VIDEO_LENGTH,
 )
 
 # Parse CLI arguments passed after `--` when launching via Streamlit


### PR DESCRIPTION
## Summary
- import `DEFAULT_VIDEO_LENGTH` into the Streamlit GUI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68778b7c4bb08329a1f0f95c2eee4ef7