### PR TITLE
Fix FramePack retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ python demo_gradio.py --port 8001
 ます。未設定時はそれぞれ `127.0.0.1` と `8001` が使われます。
 
 フレームパックの API エンドポイントは `/validate_and_process` が標準です。
-必要に応じて `FRAMEPACK_API_NAME` 環境変数で変更できます。旧エンドポイント
-`/predict` を指定すると `Cannot find a function with api_name` というエラーに
-なるため注意してください。
+必要に応じて `FRAMEPACK_API_NAME` 環境変数で変更できます。旧バージョンでは
+`/predict` が使われている場合があります。本アプリではまず
+`/validate_and_process` を呼び出し、失敗した場合は自動的に `/predict`
+へフォールバックします。
 
 API が受け取る主な引数は次の 13 個です。
 

--- a/movie_agent/framepack.py
+++ b/movie_agent/framepack.py
@@ -77,6 +77,32 @@ def generate_video(
     except Exception as e:
         if debug:
             print("[DEBUG] framepack error:", e)
+        if FRAMEPACK_API_NAME != "/predict":
+            try:
+                if debug:
+                    print("[DEBUG] retrying with /predict")
+                result = client.predict(
+                    img_param,
+                    prompt,
+                    "",
+                    seed,
+                    video_length,
+                    latent_window_size,
+                    steps,
+                    cfg,
+                    gs,
+                    rs,
+                    gpu_memory_preservation,
+                    use_teacache,
+                    mp4_crf,
+                    api_name="/predict",
+                )
+                if debug:
+                    print("[DEBUG] framepack response:", result)
+                return result
+            except Exception as e2:
+                if debug:
+                    print("[DEBUG] framepack retry error:", e2)
         return None
 
 

--- a/tests/test_framepack.py
+++ b/tests/test_framepack.py
@@ -106,3 +106,41 @@ def test_generate_video_debug(monkeypatch, capsys):
     assert "'prompt': 'p'" in out[1]
     assert "'use_teacache': True" in out[1]
     assert out[2] == '[DEBUG] framepack response: result-data'
+
+
+def test_generate_video_fallback(monkeypatch):
+    calls = []
+
+    class DummyClient:
+        def __init__(self, url):
+            pass
+
+        def predict(self, *args, api_name=None):
+            calls.append(api_name)
+            if api_name == '/validate_and_process':
+                raise Exception('fail')
+            return 'ok'
+
+    monkeypatch.setattr(framepack, 'Client', DummyClient)
+    monkeypatch.setattr(framepack, 'handle_file', lambda p: {'path': p})
+    monkeypatch.setattr(framepack, 'FRAMEPACK_HOST', '1.2.3.4')
+    monkeypatch.setattr(framepack, 'FRAMEPACK_PORT', '1234')
+    monkeypatch.setattr(framepack, 'FRAMEPACK_API_NAME', '/validate_and_process')
+
+    result = framepack.generate_video(
+        'start.png',
+        prompt='p',
+        seed=1,
+        video_length=2,
+        latent_window_size=3,
+        steps=4,
+        cfg=5.0,
+        gs=6.0,
+        rs=7.0,
+        gpu_memory_preservation=8.0,
+        use_teacache=True,
+        mp4_crf=9,
+    )
+
+    assert result == 'ok'
+    assert calls == ['/validate_and_process', '/predict']


### PR DESCRIPTION
## Summary
- retry FramePack call with `/predict` whenever the first attempt fails
- update docs for automatic fallback
- adjust tests for new behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68778e07817c83299a5109c65e1e3064