### PR TITLE
Add fn_index fallback for FramePack client

### DIFF
--- a/movie_agent/framepack.py
+++ b/movie_agent/framepack.py
@@ -103,6 +103,31 @@ def generate_video(
             except Exception as e2:
                 if debug:
                     print("[DEBUG] framepack retry error:", e2)
+        try:
+            if debug:
+                print("[DEBUG] retrying with fn_index=0")
+            result = client.predict(
+                img_param,
+                prompt,
+                "",
+                seed,
+                video_length,
+                latent_window_size,
+                steps,
+                cfg,
+                gs,
+                rs,
+                gpu_memory_preservation,
+                use_teacache,
+                mp4_crf,
+                fn_index=0,
+            )
+            if debug:
+                print("[DEBUG] framepack response:", result)
+            return result
+        except Exception as e3:
+            if debug:
+                print("[DEBUG] framepack retry error:", e3)
         return None
 
 

--- a/tests/test_framepack.py
+++ b/tests/test_framepack.py
@@ -115,8 +115,8 @@ def test_generate_video_fallback(monkeypatch):
         def __init__(self, url):
             pass
 
-        def predict(self, *args, api_name=None):
-            calls.append(api_name)
+        def predict(self, *args, api_name=None, fn_index=None):
+            calls.append(api_name if api_name is not None else fn_index)
             if api_name == '/validate_and_process':
                 raise Exception('fail')
             return 'ok'
@@ -144,3 +144,39 @@ def test_generate_video_fallback(monkeypatch):
 
     assert result == 'ok'
     assert calls == ['/validate_and_process', '/predict']
+
+
+def test_generate_video_fallback_fn_index(monkeypatch):
+    calls = []
+
+    class DummyClient:
+        def __init__(self, url):
+            pass
+
+        def predict(self, *args, api_name=None, fn_index=None):
+            calls.append(api_name if api_name is not None else fn_index)
+            raise Exception('fail')
+
+    monkeypatch.setattr(framepack, 'Client', DummyClient)
+    monkeypatch.setattr(framepack, 'handle_file', lambda p: {'path': p})
+    monkeypatch.setattr(framepack, 'FRAMEPACK_HOST', '1.2.3.4')
+    monkeypatch.setattr(framepack, 'FRAMEPACK_PORT', '1234')
+    monkeypatch.setattr(framepack, 'FRAMEPACK_API_NAME', '/validate_and_process')
+
+    result = framepack.generate_video(
+        'start.png',
+        prompt='p',
+        seed=1,
+        video_length=2,
+        latent_window_size=3,
+        steps=4,
+        cfg=5.0,
+        gs=6.0,
+        rs=7.0,
+        gpu_memory_preservation=8.0,
+        use_teacache=True,
+        mp4_crf=9,
+    )
+
+    assert result is None
+    assert calls == ['/validate_and_process', '/predict', 0]


### PR DESCRIPTION
## Summary
- support newer FramePack servers by falling back to `fn_index=0`
- update unit tests for new fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687796692e9c8329bece1f205c417ad5