### PR TITLE
Add fn_index override for framepack

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@ python demo_gradio.py --port 8001
 
 フレームパックの API エンドポイントは `/validate_and_process` が標準です。
 必要に応じて `FRAMEPACK_API_NAME` 環境変数で変更できます。旧バージョンでは
-`/predict` が使われている場合があります。本アプリではまず
+`/predict` や `/generate` が使われている場合があります。本アプリではまず
 `/validate_and_process` を呼び出し、失敗した場合は自動的に `/predict`
-へフォールバックします。
+へフォールバックし、それも失敗した場合は `fn_index` を指定して呼び出します。
+利用したい `fn_index` は `FRAMEPACK_FN_INDEX` 環境変数で設定でき、
+デフォルトは `1` です。
 
 API が受け取る主な引数は次の 13 個です。
 

--- a/movie_agent/framepack.py
+++ b/movie_agent/framepack.py
@@ -6,6 +6,7 @@ from gradio_client import Client, handle_file
 FRAMEPACK_HOST = os.getenv("FRAMEPACK_HOST", "127.0.0.1")
 FRAMEPACK_PORT = os.getenv("FRAMEPACK_PORT", "8001")
 FRAMEPACK_API_NAME = os.getenv("FRAMEPACK_API_NAME", "/validate_and_process")
+FRAMEPACK_FN_INDEX = int(os.getenv("FRAMEPACK_FN_INDEX", "1"))
 
 
 def generate_video(
@@ -105,7 +106,7 @@ def generate_video(
                     print("[DEBUG] framepack retry error:", e2)
         try:
             if debug:
-                print("[DEBUG] retrying with fn_index=0")
+                print(f"[DEBUG] retrying with fn_index={FRAMEPACK_FN_INDEX}")
             result = client.predict(
                 img_param,
                 prompt,
@@ -120,7 +121,7 @@ def generate_video(
                 gpu_memory_preservation,
                 use_teacache,
                 mp4_crf,
-                fn_index=0,
+                fn_index=FRAMEPACK_FN_INDEX,
             )
             if debug:
                 print("[DEBUG] framepack response:", result)
@@ -136,4 +137,5 @@ __all__ = [
     "FRAMEPACK_HOST",
     "FRAMEPACK_PORT",
     "FRAMEPACK_API_NAME",
+    "FRAMEPACK_FN_INDEX",
 ]

--- a/tests/test_framepack.py
+++ b/tests/test_framepack.py
@@ -22,6 +22,8 @@ def test_generate_video(monkeypatch):
     monkeypatch.setattr(framepack, 'FRAMEPACK_HOST', '1.2.3.4')
     monkeypatch.setattr(framepack, 'FRAMEPACK_PORT', '1234')
     monkeypatch.setattr(framepack, 'FRAMEPACK_API_NAME', '/validate_and_process')
+    monkeypatch.setattr(framepack, 'FRAMEPACK_FN_INDEX', 1)
+    monkeypatch.setattr(framepack, 'FRAMEPACK_FN_INDEX', 1)
 
     result = framepack.generate_video(
         'start.png',
@@ -80,7 +82,7 @@ def test_generate_video_debug(monkeypatch, capsys):
     monkeypatch.setattr(framepack, 'FRAMEPACK_HOST', '1.2.3.4')
     monkeypatch.setattr(framepack, 'FRAMEPACK_PORT', '1234')
     monkeypatch.setattr(framepack, 'FRAMEPACK_API_NAME', '/validate_and_process')
-
+    monkeypatch.setattr(framepack, 'FRAMEPACK_FN_INDEX', 1)
     result = framepack.generate_video(
         'start.png',
         prompt='p',
@@ -126,7 +128,7 @@ def test_generate_video_fallback(monkeypatch):
     monkeypatch.setattr(framepack, 'FRAMEPACK_HOST', '1.2.3.4')
     monkeypatch.setattr(framepack, 'FRAMEPACK_PORT', '1234')
     monkeypatch.setattr(framepack, 'FRAMEPACK_API_NAME', '/validate_and_process')
-
+    monkeypatch.setattr(framepack, 'FRAMEPACK_FN_INDEX', 1)
     result = framepack.generate_video(
         'start.png',
         prompt='p',
@@ -162,7 +164,7 @@ def test_generate_video_fallback_fn_index(monkeypatch):
     monkeypatch.setattr(framepack, 'FRAMEPACK_HOST', '1.2.3.4')
     monkeypatch.setattr(framepack, 'FRAMEPACK_PORT', '1234')
     monkeypatch.setattr(framepack, 'FRAMEPACK_API_NAME', '/validate_and_process')
-
+    monkeypatch.setattr(framepack, 'FRAMEPACK_FN_INDEX', 1)
     result = framepack.generate_video(
         'start.png',
         prompt='p',
@@ -179,4 +181,4 @@ def test_generate_video_fallback_fn_index(monkeypatch):
     )
 
     assert result is None
-    assert calls == ['/validate_and_process', '/predict', 0]
+    assert calls == ['/validate_and_process', '/predict', 1]


### PR DESCRIPTION
## Summary
- add `FRAMEPACK_FN_INDEX` to control which function index to call on the framepack API
- document new variable in README
- adjust tests for overridable fn index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68779a3a129c8329a0fcdb7d0eb9bb04