### PR TITLE
Add Streamlit interface for image generation and posting

### DIFF
--- a/images.csv
+++ b/images.csv
@@ -1,0 +1,1 @@
+id,category,tags,nsfw,ja_prompt,image_prompt,image_path,post_url,views_yesterday,views_week,views_month,llm_model,checkpoint,comfy_vae,comfy_lora,temperature,max_tokens,top_p,cfg,steps,seed,batch_count,width,height

--- a/movie_agent/csv_manager.py
+++ b/movie_agent/csv_manager.py
@@ -149,3 +149,114 @@ def save_data(df: pd.DataFrame, path: str) -> None:
     """Save ``df`` to ``path`` dropping the ``selected`` column."""
     df_copy = df.drop(columns=["selected"], errors="ignore")
     df_copy.to_csv(path, index=False)
+
+
+def load_image_data(path: str) -> pd.DataFrame:
+    """Load image spreadsheet data from ``path``.
+
+    Creates a DataFrame with the expected columns when the file does not
+    exist. Missing columns are added with default values.
+    """
+    columns = [
+        "selected",
+        "id",
+        "category",
+        "tags",
+        "nsfw",
+        "ja_prompt",
+        "image_prompt",
+        "image_path",
+        "post_url",
+        "views_yesterday",
+        "views_week",
+        "views_month",
+        "llm_model",
+        "checkpoint",
+        "comfy_vae",
+        "comfy_lora",
+        "temperature",
+        "max_tokens",
+        "top_p",
+        "cfg",
+        "steps",
+        "seed",
+        "batch_count",
+        "width",
+        "height",
+    ]
+
+    try:
+        df = pd.read_csv(path)
+    except FileNotFoundError:
+        df = pd.DataFrame(columns=columns)
+        df["selected"] = False
+        df["id"] = ""
+        df["category"] = ""
+        df["tags"] = ""
+        df["nsfw"] = False
+        df["ja_prompt"] = ""
+        df["image_prompt"] = ""
+        df["image_path"] = ""
+        df["post_url"] = ""
+        df["views_yesterday"] = 0
+        df["views_week"] = 0
+        df["views_month"] = 0
+        df["llm_model"] = DEFAULT_MODEL
+        df["checkpoint"] = ""
+        df["comfy_vae"] = ""
+        df["comfy_lora"] = ""
+        df["temperature"] = DEFAULT_TEMPERATURE
+        df["max_tokens"] = DEFAULT_MAX_TOKENS
+        df["top_p"] = DEFAULT_TOP_P
+        df["cfg"] = DEFAULT_CFG
+        df["steps"] = DEFAULT_STEPS
+        df["seed"] = DEFAULT_SEED
+        df["batch_count"] = 1
+        df["width"] = DEFAULT_WIDTH
+        df["height"] = DEFAULT_HEIGHT
+    else:
+        missing_cols = [c for c in columns if c not in df.columns]
+        for c in missing_cols:
+            if c in ["selected", "nsfw"]:
+                df[c] = False
+            elif c in ["views_yesterday", "views_week", "views_month"]:
+                df[c] = 0
+            else:
+                df[c] = ""
+        if "llm_model" in missing_cols:
+            df["llm_model"] = DEFAULT_MODEL
+        if "temperature" in missing_cols:
+            df["temperature"] = DEFAULT_TEMPERATURE
+        if "max_tokens" in missing_cols:
+            df["max_tokens"] = DEFAULT_MAX_TOKENS
+        if "top_p" in missing_cols:
+            df["top_p"] = DEFAULT_TOP_P
+        if "cfg" in missing_cols:
+            df["cfg"] = DEFAULT_CFG
+        if "steps" in missing_cols:
+            df["steps"] = DEFAULT_STEPS
+        if "seed" in missing_cols:
+            df["seed"] = DEFAULT_SEED
+        if "batch_count" in missing_cols:
+            df["batch_count"] = 1
+        if "width" in missing_cols:
+            df["width"] = DEFAULT_WIDTH
+        if "height" in missing_cols:
+            df["height"] = DEFAULT_HEIGHT
+
+        df = df[columns]
+        df["selected"] = df["selected"].fillna(False).astype(bool)
+        df["nsfw"] = df["nsfw"].fillna(False).astype(bool)
+        df["id"] = df["id"].astype(str)
+        df["category"] = df["category"].fillna("").astype(str)
+        df["tags"] = df["tags"].fillna("").astype(str)
+        df["ja_prompt"] = df["ja_prompt"].fillna("").astype(str)
+        df["image_prompt"] = df["image_prompt"].fillna("").astype(str)
+        df["image_path"] = df["image_path"].fillna("").astype(str)
+        df["post_url"] = df["post_url"].fillna("").astype(str)
+        for vcol in ["views_yesterday", "views_week", "views_month"]:
+            df[vcol] = (
+                pd.to_numeric(df[vcol], errors="coerce").fillna(0).astype(int)
+            )
+    return df
+

--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -1,0 +1,284 @@
+import argparse
+import os
+from datetime import datetime
+from pathlib import Path
+
+import requests
+import streamlit as st
+from .comfyui import (
+    list_comfy_models,
+    generate_image,
+    DEFAULT_CFG,
+    DEFAULT_STEPS,
+)
+from .ollama import list_ollama_models, generate_story_prompt, DEBUG_MODE
+from .csv_manager import (
+    load_image_data,
+    save_data,
+    slugify,
+    unique_path,
+    DEFAULT_MODEL,
+    DEFAULT_TEMPERATURE,
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_TOP_P,
+    DEFAULT_WIDTH,
+    DEFAULT_HEIGHT,
+    DEFAULT_SEED,
+)
+
+# Parse CLI arguments passed after `--` when launching via Streamlit
+parser = argparse.ArgumentParser(add_help=False)
+parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+args, _ = parser.parse_known_args()
+if args.debug:
+    print("[DEBUG] Debug mode enabled")
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+CSV_FILE = str(BASE_DIR / "images.csv")
+AUTOPOSTER_API_URL = os.getenv("AUTOPOSTER_API_URL", "http://127.0.0.1:9000")
+
+st.set_page_config(page_title="Image Agent", layout="wide")
+
+
+def main() -> None:
+    """Run the Streamlit UI for image generation and posting."""
+    msg = st.session_state.pop("just_rerun", None)
+    if msg:
+        st.info(msg)
+
+    st.title("Image Generation Agent")
+
+    if "image_df" not in st.session_state:
+        st.session_state.image_df = load_image_data(CSV_FILE)
+        st.session_state.last_saved_df = st.session_state.image_df.copy()
+    if "last_saved_df" not in st.session_state:
+        st.session_state.last_saved_df = st.session_state.image_df.copy()
+    if "autosave" not in st.session_state:
+        st.session_state.autosave = False
+    if "models" not in st.session_state:
+        st.session_state.models = list_ollama_models()
+    if "comfy_models" not in st.session_state:
+        (
+            st.session_state.comfy_models,
+            st.session_state.comfy_vaes,
+            st.session_state.comfy_loras,
+        ) = list_comfy_models()
+
+    df = st.session_state.image_df
+    for col, options in [
+        ("llm_model", st.session_state.models),
+        ("checkpoint", st.session_state.comfy_models),
+        ("comfy_vae", st.session_state.comfy_vaes),
+    ]:
+        if col not in df.columns:
+            df[col] = ""
+        else:
+            df[col] = df[col].fillna("")
+    st.session_state.image_df = df
+
+    st.write("### Image Spreadsheet")
+    edited_df = st.data_editor(
+        df,
+        column_config={
+            "selected": st.column_config.CheckboxColumn("Select"),
+            "id": st.column_config.TextColumn("ID"),
+            "category": st.column_config.TextColumn("Category"),
+            "tags": st.column_config.TextColumn("Tags"),
+            "nsfw": st.column_config.CheckboxColumn("NSFW"),
+            "ja_prompt": st.column_config.TextAreaColumn("Japanese Prompt"),
+            "image_prompt": st.column_config.TextAreaColumn("Image Prompt"),
+            "image_path": st.column_config.TextColumn("Image Path"),
+            "post_url": st.column_config.TextColumn("Post URL"),
+            "views_yesterday": st.column_config.NumberColumn(
+                "Views Yesterday", min_value=0
+            ),
+            "views_week": st.column_config.NumberColumn("Views Week", min_value=0),
+            "views_month": st.column_config.NumberColumn("Views Month", min_value=0),
+            "llm_model": st.column_config.SelectboxColumn(
+                "LLM Model", options=st.session_state.models
+            ),
+            "checkpoint": st.column_config.SelectboxColumn(
+                "Checkpoint", options=st.session_state.comfy_models
+            ),
+            "comfy_vae": st.column_config.SelectboxColumn(
+                "VAE", options=st.session_state.comfy_vaes
+            ),
+            "steps": st.column_config.NumberColumn("Steps", min_value=1),
+            "seed": st.column_config.NumberColumn("Seed", min_value=0),
+            "batch_count": st.column_config.NumberColumn(
+                "Batch", min_value=1, max_value=10
+            ),
+            "width": st.column_config.NumberColumn("Width", min_value=64),
+            "height": st.column_config.NumberColumn("Height", min_value=64),
+        },
+        num_rows="dynamic",
+        hide_index=True,
+    )
+    st.session_state.image_df = edited_df
+
+    prompt_col, gen_col, post_col, anal_col = st.columns(4)
+
+    if prompt_col.button("Generate prompt"):
+        df = st.session_state.image_df
+        selected = df[df["selected"]]
+        for idx, row in selected.iterrows():
+            ja = row.get("ja_prompt", "")
+            if not row.get("image_prompt"):
+                if ja:
+                    try:
+                        prompt = generate_story_prompt(
+                            ja,
+                            model=row.get("llm_model", DEFAULT_MODEL),
+                            temperature=row.get("temperature", DEFAULT_TEMPERATURE),
+                            max_tokens=row.get("max_tokens", DEFAULT_MAX_TOKENS),
+                            top_p=row.get("top_p", DEFAULT_TOP_P),
+                        )
+                        df.at[idx, "image_prompt"] = prompt
+                    except Exception as e:
+                        st.error(
+                            f"Prompt generation failed for row {row.get('id', idx)}: {e}"
+                        )
+            else:
+                st.warning(
+                    f"Row {row.get('id', idx)} already has an image_prompt"
+                )
+        st.session_state.image_df = df
+        if st.session_state.autosave:
+            save_data(df, CSV_FILE)
+
+    if gen_col.button("Generate images"):
+        df = st.session_state.image_df
+        selected = df[df["selected"]]
+        for idx, row in selected.iterrows():
+            prompt = row.get("image_prompt", "")
+            if not prompt:
+                st.warning(f"No image_prompt for row {row.get('id', idx)}")
+                continue
+            checkpoint = row.get("checkpoint") or ""
+            vae = row.get("comfy_vae") or ""
+            seed_val = int(row.get("seed", DEFAULT_SEED) or DEFAULT_SEED)
+            steps_val = int(row.get("steps", DEFAULT_STEPS) or DEFAULT_STEPS)
+            width_val = int(row.get("width", DEFAULT_WIDTH) or DEFAULT_WIDTH)
+            height_val = int(row.get("height", DEFAULT_HEIGHT) or DEFAULT_HEIGHT)
+            batch = int(row.get("batch_count", 1) or 1)
+
+            for b in range(batch):
+                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                category = slugify(row.get("category", ""))
+                model_slug = slugify(checkpoint or "model")
+                filename = f"{timestamp}_{model_slug}_{b}.png"
+                base_dir = Path(BASE_DIR) / "imgs" / category
+                os.makedirs(base_dir, exist_ok=True)
+                out_path = unique_path(str(base_dir / filename))
+
+                try:
+                    img_bytes = generate_image(
+                        prompt,
+                        checkpoint=checkpoint,
+                        vae=vae,
+                        seed=seed_val + b,
+                        width=width_val,
+                        height=height_val,
+                        cfg=row.get("cfg", DEFAULT_CFG),
+                        steps=steps_val,
+                        debug=DEBUG_MODE,
+                    )
+                    if img_bytes:
+                        with open(out_path, "wb") as f:
+                            f.write(img_bytes)
+                        df.at[idx, "image_path"] = out_path
+                        st.success(f"Saved image to {out_path}")
+                    else:
+                        st.error(
+                            f"Failed to generate image for row {row.get('id', idx)}"
+                        )
+                except Exception as e:
+                    st.error(
+                        f"Image generation error for row {row.get('id', idx)}: {e}"
+                    )
+        st.session_state.image_df = df
+        if st.session_state.autosave:
+            save_data(df, CSV_FILE)
+
+    if post_col.button("Post"):
+        df = st.session_state.image_df
+        selected = df[df["selected"]]
+        for idx, row in selected.iterrows():
+            image_path = row.get("image_path", "")
+            if not image_path or not os.path.exists(image_path):
+                st.warning(f"No image file for row {row.get('id', idx)}")
+                continue
+            title = row.get("id", "")
+            tags = row.get("tags", "")
+            try:
+                files = {"file": open(image_path, "rb")}
+            except Exception:
+                st.error(f"Unable to open image {image_path}")
+                continue
+            try:
+                res = requests.post(
+                    f"{AUTOPOSTER_API_URL}/post",
+                    data={"title": title, "tags": tags},
+                    files=files,
+                    timeout=10,
+                )
+                res.raise_for_status()
+                url = res.json().get("url", "")
+                if url:
+                    df.at[idx, "post_url"] = url
+                    st.success(f"Posted: {url}")
+                else:
+                    st.error("No URL returned from autoPoster")
+            except Exception as e:
+                st.error(
+                    f"Posting failed for row {row.get('id', idx)}: {e}"
+                )
+            finally:
+                files["file"].close()
+        st.session_state.image_df = df
+        if st.session_state.autosave:
+            save_data(df, CSV_FILE)
+
+    if anal_col.button("Analysis"):
+        df = st.session_state.image_df
+        selected = df[df["selected"]]
+        for idx, row in selected.iterrows():
+            url = row.get("post_url", "")
+            if not url:
+                st.warning(f"No post_url for row {row.get('id', idx)}")
+                continue
+            try:
+                res = requests.get(
+                    f"{AUTOPOSTER_API_URL}/stats",
+                    params={"url": url},
+                    timeout=10,
+                )
+                res.raise_for_status()
+                data = res.json()
+                df.at[idx, "views_yesterday"] = data.get(
+                    "views_yesterday", row.get("views_yesterday", 0)
+                )
+                df.at[idx, "views_week"] = data.get(
+                    "views_week", row.get("views_week", 0)
+                )
+                df.at[idx, "views_month"] = data.get(
+                    "views_month", row.get("views_month", 0)
+                )
+            except Exception as e:
+                st.error(f"Analysis failed for row {row.get('id', idx)}: {e}")
+        st.session_state.image_df = df
+        if st.session_state.autosave:
+            save_data(df, CSV_FILE)
+
+    save_col, auto_col = st.columns([1, 1])
+    auto_col.checkbox("Auto-save", value=st.session_state.autosave, key="autosave")
+    if save_col.button("Save CSV"):
+        df = st.session_state.image_df.copy()
+        st.session_state.image_df = df
+        save_data(df, CSV_FILE)
+        st.session_state.last_saved_df = df.copy()
+        st.success("Saved to CSV")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `load_image_data` helper to manage new image spreadsheet
- implement `image_ui` Streamlit app that loads/saves `images.csv`
- support prompt generation, image creation, posting and analytics placeholders

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892e78df6d48329946a9c301e9d5137