### PR TITLE
Add scripts for launching image UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,22 @@ conda activate movieagent
 Windows 環境では付属の `start_movie_agent.bat` を実行してください。仮想環境
 が存在しない場合は自動的に作成してから Streamlit を起動します。`movieagent`
 conda 環境を利用している場合は、`start_movie_agent_conda.bat` を使用すると
-`conda activate movieagent` を実行した後に同様の方法で UI を起動できます。
+`conda activate movieagent` を実行した後に同様の方法で UI を起動できます。画像
+投稿用 UI を使う際は `start_image_ui.bat` または `start_image_ui_conda.bat` を
+実行してください。
 
 ```bash
 start_movie_agent.bat
 REM または conda 環境用
 start_movie_agent_conda.bat
+
+start_image_ui.bat
+REM 画像 UI を conda 環境で起動
+start_image_ui_conda.bat
 ```
 
-実行後、ブラウザで [http://localhost:8501](http://localhost:8501) を開くと UI が表示されます。
+実行後、いずれもデフォルトのブラウザで [http://localhost:8501](http://localhost:8501)
+を開くと UI が表示されます。
 
 
 動画リストは **Streamlit Data Editor** を利用しており、`num_rows="dynamic"`

--- a/start_image_ui.bat
+++ b/start_image_ui.bat
@@ -1,0 +1,17 @@
+@echo off
+REM Activate virtual environment if not already active
+if not defined VIRTUAL_ENV (
+    if exist .venv\Scripts\activate.bat (
+        call .venv\Scripts\activate.bat
+    ) else (
+        python -m venv .venv
+        call .venv\Scripts\activate.bat
+        pip install -r requirements.txt
+    )
+)
+
+REM Set PYTHONPATH to the project root so movie_agent package resolves
+set PYTHONPATH=%~dp0
+
+REM Launch Streamlit app with debug mode
+streamlit run movie_agent/image_ui.py -- --debug

--- a/start_image_ui_conda.bat
+++ b/start_image_ui_conda.bat
@@ -1,0 +1,9 @@
+@echo off
+REM Activate movieagent conda environment
+call conda activate movieagent
+
+REM Set PYTHONPATH to the project root so movie_agent package resolves
+set PYTHONPATH=%~dp0
+
+REM Launch Streamlit app with debug mode
+streamlit run movie_agent/image_ui.py -- --debug


### PR DESCRIPTION
## Summary
- add `start_image_ui.bat` to launch the image UI with virtual-env handling
- add `start_image_ui_conda.bat` for conda environments
- document new scripts and default port in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892ec5f864c832996c706960e1ee50f