### PR TITLE
Use absolute imports for image UI and update start scripts

### DIFF
--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -5,14 +5,18 @@ from pathlib import Path
 
 import requests
 import streamlit as st
-from .comfyui import (
+from movie_agent.comfyui import (
     list_comfy_models,
     generate_image,
     DEFAULT_CFG,
     DEFAULT_STEPS,
 )
-from .ollama import list_ollama_models, generate_story_prompt, DEBUG_MODE
-from .csv_manager import (
+from movie_agent.ollama import (
+    list_ollama_models,
+    generate_story_prompt,
+    DEBUG_MODE,
+)
+from movie_agent.csv_manager import (
     load_image_data,
     save_data,
     slugify,

--- a/start_image_ui.bat
+++ b/start_image_ui.bat
@@ -1,4 +1,7 @@
 @echo off
+REM Ensure the script runs from the project root
+cd /d %~dp0
+
 REM Activate virtual environment if not already active
 if not defined VIRTUAL_ENV (
     if exist .venv\Scripts\activate.bat (
@@ -9,9 +12,6 @@ if not defined VIRTUAL_ENV (
         pip install -r requirements.txt
     )
 )
-
-REM Set PYTHONPATH to the project root so movie_agent package resolves
-set PYTHONPATH=%~dp0
 
 REM Launch Streamlit app with debug mode
 streamlit run movie_agent/image_ui.py -- --debug

--- a/start_image_ui_conda.bat
+++ b/start_image_ui_conda.bat
@@ -1,9 +1,9 @@
 @echo off
+REM Ensure the script runs from the project root
+cd /d %~dp0
+
 REM Activate movieagent conda environment
 call conda activate movieagent
-
-REM Set PYTHONPATH to the project root so movie_agent package resolves
-set PYTHONPATH=%~dp0
 
 REM Launch Streamlit app with debug mode
 streamlit run movie_agent/image_ui.py -- --debug


### PR DESCRIPTION
## Summary
- switch image_ui module to absolute imports from the movie_agent package
- streamline Windows start scripts and ensure they run from repo root

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892ffe61774832984ed156b1044a69e