### PR TITLE
Use TextColumn for image prompts

### DIFF
--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -89,8 +89,8 @@ def main() -> None:
             "category": st.column_config.TextColumn("Category"),
             "tags": st.column_config.TextColumn("Tags"),
             "nsfw": st.column_config.CheckboxColumn("NSFW"),
-            "ja_prompt": st.column_config.TextAreaColumn("Japanese Prompt"),
-            "image_prompt": st.column_config.TextAreaColumn("Image Prompt"),
+            "ja_prompt": st.column_config.TextColumn("Japanese Prompt"),
+            "image_prompt": st.column_config.TextColumn("Image Prompt"),
             "image_path": st.column_config.TextColumn("Image Path"),
             "post_url": st.column_config.TextColumn("Post URL"),
             "views_yesterday": st.column_config.NumberColumn(


### PR DESCRIPTION
## Summary
- Replace `TextAreaColumn` with `TextColumn` for `ja_prompt` and `image_prompt` in image UI
- Ensure image UI column types align with video GUI configuration

## Testing
- `pytest`
- `streamlit run movie_agent/image_ui.py`

------
https://chatgpt.com/codex/tasks/task_e_689309f2cfc08329afe33802073959ce