### PR TITLE
Ensure PYTHONPATH is set in image UI batch

### DIFF
--- a/start_image_ui.bat
+++ b/start_image_ui.bat
@@ -13,5 +13,8 @@ if not defined VIRTUAL_ENV (
     )
 )
 
+REM Set PYTHONPATH to project root
+set PYTHONPATH=%~dp0
+
 REM Launch Streamlit app with debug mode
 streamlit run movie_agent/image_ui.py -- --debug


### PR DESCRIPTION
## Summary
- ensure Windows start script sets PYTHONPATH to project root after virtual environment activation

## Testing
- `pytest`
- `python -c "import movie_agent"` from outside repo fails
- `PYTHONPATH=/workspace/movieAgent python -c "import movie_agent"`

------
https://chatgpt.com/codex/tasks/task_e_68930b522c7083298abe9d01c9d95fa5