### PR TITLE
feat: add configurable ollama timeout

### DIFF
--- a/movie_agent/gui.py
+++ b/movie_agent/gui.py
@@ -45,6 +45,7 @@ DEFAULT_TEMPERATURE = 0.7
 DEFAULT_MAX_TOKENS = 4096
 DEFAULT_TOP_P = 0.95
 DEFAULT_SEED = 31337
+DEFAULT_OLLAMA_TIMEOUT = 300
 
 # FramePack default parameters
 DEFAULT_LATENT_WINDOW_SIZE = 9
@@ -109,6 +110,10 @@ def main() -> None:
             df[col] = ""
         else:
             df[col] = df[col].fillna("")
+    if "timeout" not in df.columns:
+        df["timeout"] = DEFAULT_OLLAMA_TIMEOUT
+    else:
+        df["timeout"] = df["timeout"].fillna(DEFAULT_OLLAMA_TIMEOUT)
     st.session_state.video_df = df
 
     st.write("### Video Spreadsheet")
@@ -163,6 +168,11 @@ def main() -> None:
                 step=0.05,
                 min_value=0.0,
                 max_value=1.0,
+            ),
+            "timeout": st.column_config.NumberColumn(
+                "Timeout",
+                min_value=1,
+                step=1,
             ),
             "cfg": st.column_config.NumberColumn(
                 "CFG",
@@ -260,6 +270,10 @@ def main() -> None:
             if pd.isna(top_p) or top_p == "":
                 top_p = DEFAULT_TOP_P
             top_p = float(top_p)
+            timeout = row.get("timeout", DEFAULT_OLLAMA_TIMEOUT)
+            if pd.isna(timeout) or timeout == "":
+                timeout = DEFAULT_OLLAMA_TIMEOUT
+            timeout = int(timeout)
             if synopsis:
                 prompt = generate_story_prompt(
                     synopsis,
@@ -268,6 +282,7 @@ def main() -> None:
                     max_tokens,
                     top_p,
                     debug=DEBUG_MODE,
+                    timeout=timeout,
                 )
                 if prompt is not None:
                     df.at[idx, "story_prompt"] = prompt

--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -40,6 +40,7 @@ if args.debug:
 BASE_DIR = Path(__file__).resolve().parent.parent
 CSV_FILE = str(BASE_DIR / "images.csv")
 AUTOPOSTER_API_URL = os.getenv("AUTOPOSTER_API_URL", "http://127.0.0.1:9000")
+DEFAULT_TIMEOUT = 300
 
 st.set_page_config(page_title="Image Agent", layout="wide")
 
@@ -79,6 +80,10 @@ def main() -> None:
             df[col] = ""
         else:
             df[col] = df[col].fillna("")
+    if "timeout" not in df.columns:
+        df["timeout"] = DEFAULT_TIMEOUT
+    else:
+        df["timeout"] = df["timeout"].fillna(DEFAULT_TIMEOUT)
     st.session_state.image_df = df
 
     st.write("### Image Spreadsheet")
@@ -115,6 +120,7 @@ def main() -> None:
             ),
             "width": st.column_config.NumberColumn("Width", min_value=64),
             "height": st.column_config.NumberColumn("Height", min_value=64),
+            "timeout": st.column_config.NumberColumn("Timeout", min_value=1),
         },
         num_rows="dynamic",
         hide_index=True,
@@ -140,6 +146,7 @@ def main() -> None:
                             temperature=row.get("temperature", DEFAULT_TEMPERATURE),
                             max_tokens=row.get("max_tokens", DEFAULT_MAX_TOKENS),
                             top_p=row.get("top_p", DEFAULT_TOP_P),
+                            timeout=int(row.get("timeout", DEFAULT_TIMEOUT) or DEFAULT_TIMEOUT),
                         )
                         df.at[idx, "image_prompt"] = prompt
                     except Exception as e:

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -38,5 +38,7 @@ def test_generate_story_prompt(monkeypatch):
         return FakeResponse()
 
     monkeypatch.setattr(requests, "post", fake_post)
-    result = generate_story_prompt("A synopsis", "phi3:mini", 0.7, 10, 0.9)
+    result = generate_story_prompt(
+        "A synopsis", "phi3:mini", 0.7, 10, 0.9, stream=False
+    )
     assert result == "Once upon a time"


### PR DESCRIPTION
## Summary
- allow configuring Ollama request timeout and read streaming responses
- expose timeout parameter in Streamlit GUIs for video and image prompts
- update tests for new generate_story_prompt interface

## Testing
- `pytest -q`
- `streamlit run movie_agent/app.py -- --debug` *(fails: connection to Ollama not available)*
- `python - <<'PY' from movie_agent.ollama import generate_story_prompt ...` *(fails: connection to Ollama not available)*

------
https://chatgpt.com/codex/tasks/task_e_6893eca610148329a8e7218997664667