### PR TITLE
Handle reasoning fields in Ollama responses

### DIFF
--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -26,10 +26,10 @@ def test_list_ollama_models(monkeypatch):
 def test_generate_story_prompt(monkeypatch):
     class FakeResponse:
         status_code = 200
-        text = '{"response": "Once upon a time"}'
+        text = '{"response": "Once upon a time", "analysis": "because of reasons"}'
 
         def json(self):
-            return {"response": "Once upon a time"}
+            return {"response": "Once upon a time", "analysis": "because of reasons"}
 
         def raise_for_status(self):
             pass


### PR DESCRIPTION
## Summary
- log full JSON responses when debugging
- capture optional thinking/analysis reasoning fields from Ollama and print them in debug mode
- update tests with sample reasoning structure

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893eed803008329959f4bbac9ade07d