### PR TITLE
Stop streaming from Ollama prompt generation

### DIFF
--- a/movie_agent/gui.py
+++ b/movie_agent/gui.py
@@ -275,6 +275,7 @@ def main() -> None:
                 timeout = DEFAULT_OLLAMA_TIMEOUT
             timeout = int(timeout)
             if synopsis:
+                # generate_story_prompt now returns the full response in one go
                 prompt = generate_story_prompt(
                     synopsis,
                     model,

--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -140,13 +140,16 @@ def main() -> None:
                         model = row.get("llm_model")
                         if not model:
                             model = DEFAULT_MODEL
+                        # Request the full prompt response without streaming
                         prompt = generate_story_prompt(
                             ja,
                             model=model,
                             temperature=row.get("temperature", DEFAULT_TEMPERATURE),
                             max_tokens=row.get("max_tokens", DEFAULT_MAX_TOKENS),
                             top_p=row.get("top_p", DEFAULT_TOP_P),
-                            timeout=int(row.get("timeout", DEFAULT_TIMEOUT) or DEFAULT_TIMEOUT),
+                            timeout=int(
+                                row.get("timeout", DEFAULT_TIMEOUT) or DEFAULT_TIMEOUT
+                            ),
                         )
                         df.at[idx, "image_prompt"] = prompt
                     except Exception as e:

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -39,6 +39,6 @@ def test_generate_story_prompt(monkeypatch):
 
     monkeypatch.setattr(requests, "post", fake_post)
     result = generate_story_prompt(
-        "A synopsis", "phi3:mini", 0.7, 10, 0.9, stream=False
+        "A synopsis", "phi3:mini", 0.7, 10, 0.9
     )
     assert result == "Once upon a time"


### PR DESCRIPTION
## Summary
- Simplify `generate_story_prompt` to always fetch a full JSON response and print any reasoning trail
- Update Streamlit UIs to reflect non-streaming prompt generation
- Adjust tests for new `generate_story_prompt` signature

## Testing
- `pytest -q`
- `streamlit run movie_agent/gui.py --server.headless true --server.port 8501`
- `streamlit run movie_agent/image_ui.py --server.headless true --server.port 8502`


------
https://chatgpt.com/codex/tasks/task_e_6893f32ea98483299bbd5687563a9405