### PR TITLE
Refactor Ollama prompt handling and defaults

### DIFF
--- a/movie_agent/csv_manager.py
+++ b/movie_agent/csv_manager.py
@@ -6,7 +6,7 @@ from .comfyui import DEFAULT_CFG, DEFAULT_STEPS
 
 # Default generation parameters used when initializing a new CSV
 DEFAULT_MODEL = "gpt-oss:20b"
-DEFAULT_TEMPERATURE = 0.7
+DEFAULT_TEMPERATURE = 0.8
 DEFAULT_MAX_TOKENS = 4096
 DEFAULT_TOP_P = 0.95
 DEFAULT_SEED = 31337

--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import requests
 import streamlit as st
+import pandas as pd
 from movie_agent.comfyui import (
     list_comfy_models,
     generate_image,
@@ -22,9 +23,6 @@ from movie_agent.csv_manager import (
     slugify,
     unique_path,
     DEFAULT_MODEL,
-    DEFAULT_TEMPERATURE,
-    DEFAULT_MAX_TOKENS,
-    DEFAULT_TOP_P,
     DEFAULT_WIDTH,
     DEFAULT_HEIGHT,
     DEFAULT_SEED,
@@ -141,15 +139,18 @@ def main() -> None:
                         if not model:
                             model = DEFAULT_MODEL
                         # Request the full prompt response without streaming
+                        kwargs = {}
+                        for key in ("temperature", "max_tokens", "top_p"):
+                            val = row.get(key)
+                            if pd.notna(val) and val != "":
+                                kwargs[key] = val
                         prompt = generate_story_prompt(
                             ja,
                             model=model,
-                            temperature=row.get("temperature", DEFAULT_TEMPERATURE),
-                            max_tokens=row.get("max_tokens", DEFAULT_MAX_TOKENS),
-                            top_p=row.get("top_p", DEFAULT_TOP_P),
                             timeout=int(
                                 row.get("timeout", DEFAULT_TIMEOUT) or DEFAULT_TIMEOUT
                             ),
+                            **kwargs,
                         )
                         df.at[idx, "image_prompt"] = prompt
                     except Exception as e:


### PR DESCRIPTION
## Summary
- Build Ollama request payload with `options` and default `temperature=0.8`, stripping reasoning tags before returning the final text
- Set CSV manager and UI to rely on the 0.8 temperature default and pass only non-null parameters
- Update tests to the new interface and defaults

## Testing
- `pytest -q`
- Sample `generate_story_prompt` call with patched `requests.post` using `gpt-oss:20b`

------
https://chatgpt.com/codex/tasks/task_e_6894045dfd54832981136301b75c622d