### PR TITLE
feat: link image folder paths in image UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,10 +96,11 @@ streamlit run movie_agent/app.py
 
 ### 必須列
 `category`, `tags`, `nsfw`, `ja_prompt`, `llm_model`, `image_prompt`, `image_path`, `post_url`, `views_yesterday`, `views_week`, `views_month` が最低限必要です。`llm_model` は英語プロンプト生成に使用する Ollama モデルを指定し、デフォルトは `gpt-oss:20b` です。シートでは `image_prompt` 列の前に配置してください。既存の LLM / ComfyUI パラメータ列も併用できます。
+`image_path` には生成した画像をまとめたフォルダの絶対パス (file URI) を保存し、クリックで直接開くことができます。
 
 ### ボタン
 - **Generate prompt** – `ja_prompt` を英語 `image_prompt` へ変換
-- **Generate images** – ComfyUI で画像生成
+- **Generate images** – ComfyUI で画像生成し、フォルダパスを `image_path` に保存
 - **Post** – autoPoster へ投稿
 - **Analysis** – autoPoster から視聴数取得
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Include the following columns in your sheet:
 - `ja_prompt`
 - `llm_model`
 - `image_prompt`
-- `image_path`
+- `image_path` – absolute file URI of the folder containing generated images
 - `post_url`
 - `views_yesterday`
 - `views_week`
@@ -161,7 +161,7 @@ Additional LLM or ComfyUI parameter columns (model, temperature, steps, seed, wi
 
 ### Button actions
 - **Generate prompt** – use Ollama to convert `ja_prompt` into an English `image_prompt`.
-- **Generate images** – call ComfyUI to create an image saved at `image_path`.
+- **Generate images** – call ComfyUI to create images in a unique folder; `image_path` stores the folder URI.
 - **Post** – upload the image via the local `autoPoster` API and store the resulting `post_url`.
 - **Analysis** – query the `autoPoster` API to fill `views_yesterday`, `views_week`, and `views_month`.
 


### PR DESCRIPTION
## Summary
- save each row's images in a dedicated timestamped directory and store its file URI
- render `image_path` as clickable link in Streamlit Data Editor
- document that `image_path` points to an absolute folder containing generated images

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68942d18d06c8329a5b53cbac91ace5e