### PR TITLE
feat: organize generated images by folder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ streamlit run movie_agent/app.py
 
 ### ボタン
 - **Generate prompt** – `ja_prompt` を英語 `image_prompt` へ変換
-- **Generate images** – ComfyUI で画像生成
+- **Generate images** – ComfyUI で画像生成。生成された画像は `items/<category>_<tags>_<checkpoint>_<YYYYMMDD_HHMMSS>/` というタイムスタンプ付きフォルダに保存され、`image_path` 列にはそのフォルダの絶対パス (`file://...`) がクリック可能なリンクとして記録されます。
 - **Post** – autoPoster へ投稿
 - **Analysis** – autoPoster から視聴数取得
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Additional LLM or ComfyUI parameter columns (model, temperature, steps, seed, wi
 
 ### Button actions
 - **Generate prompt** – use Ollama to convert `ja_prompt` into an English `image_prompt`.
-- **Generate images** – call ComfyUI to create an image saved at `image_path`.
+- **Generate images** – call ComfyUI to create images in a timestamped folder named `items/<category>_<tags>_<checkpoint>_<YYYYMMDD_HHMMSS>/`. The `image_path` column stores a `file://` URI to this folder, which Streamlit renders as a clickable link.
 - **Post** – upload the image via the local `autoPoster` API and store the resulting `post_url`.
 - **Analysis** – query the `autoPoster` API to fill `views_yesterday`, `views_week`, and `views_month`.
 

--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -21,7 +21,6 @@ from movie_agent.csv_manager import (
     load_image_data,
     save_data,
     slugify,
-    unique_path,
     DEFAULT_MODEL,
     DEFAULT_WIDTH,
     DEFAULT_HEIGHT,
@@ -122,7 +121,7 @@ def main() -> None:
                 "LLM Model", options=st.session_state.models
             ),
             "image_prompt": st.column_config.TextColumn("Image Prompt"),
-            "image_path": st.column_config.TextColumn("Image Path"),
+            "image_path": st.column_config.LinkColumn("Image Path"),
             "post_url": st.column_config.TextColumn("Post URL"),
             "views_yesterday": st.column_config.NumberColumn(
                 "Views Yesterday", min_value=0
@@ -241,18 +240,18 @@ def main() -> None:
             if pd.isna(batch) or str(batch).strip() == "":
                 batch = 1
             batch = int(batch)
+            tag_str = row.get("tags", "")
+            category_raw = row.get("category", "")
+            folder_name = (
+                f"{slugify(category_raw)}_{slugify(tag_str)}_{checkpoint}_"
+                f"{datetime.now():%Y%m%d_%H%M%S}"
+            )
+            folder_path = Path("items") / folder_name
+            os.makedirs(folder_path, exist_ok=True)
 
             for b in range(batch):
-                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-                category = slugify(row.get("category", ""))
-                model_slug = slugify(checkpoint or "model")
-                filename = f"{timestamp}_{model_slug}_{b}.png"
-                base_dir = Path(BASE_DIR) / "imgs" / category
-                os.makedirs(base_dir, exist_ok=True)
-                out_path = unique_path(str(base_dir / filename))
-
                 try:
-                    img_bytes = generate_image(
+                    paths = generate_image(
                         prompt,
                         checkpoint=checkpoint,
                         vae=vae,
@@ -261,13 +260,13 @@ def main() -> None:
                         height=height_val,
                         cfg=cfg_val,
                         steps=steps_val,
+                        output_dir=folder_path,
+                        prefix=f"batch{b}",
                         debug=DEBUG_MODE,
                     )
-                    if img_bytes:
-                        with open(out_path, "wb") as f:
-                            f.write(img_bytes)
-                        df.at[idx, "image_path"] = out_path
-                        st.success(f"Saved image to {out_path}")
+                    if paths:
+                        for p in paths:
+                            st.success(f"Saved image to {p}")
                     else:
                         st.error(
                             f"Failed to generate image for row {row.get('id', idx)}"
@@ -276,6 +275,8 @@ def main() -> None:
                     st.error(
                         f"Image generation error for row {row.get('id', idx)}: {e}"
                     )
+
+            df.at[idx, "image_path"] = folder_path.resolve().as_uri()
         st.session_state.image_df = df
         if st.session_state.autosave:
             save_data(df, CSV_FILE)

--- a/tests/test_comfyui.py
+++ b/tests/test_comfyui.py
@@ -36,7 +36,7 @@ def test_list_comfy_models(monkeypatch):
     assert loras == ["", "lora1"]
 
 
-def test_generate_image(monkeypatch):
+def test_generate_image(monkeypatch, tmp_path):
     class FakeResponse:
         def __init__(self, data=None, content=b""):
             self.status_code = 200
@@ -71,5 +71,15 @@ def test_generate_image(monkeypatch):
     monkeypatch.setattr(requests, "get", fake_get)
     monkeypatch.setattr(time, "sleep", lambda x: None)
 
-    data = generate_image("p", "ckpt", "", 1, cfg=5, steps=20)
-    assert data == b"image-bytes"
+    paths = generate_image(
+        "p",
+        "ckpt",
+        "",
+        1,
+        cfg=5,
+        steps=20,
+        output_dir=tmp_path,
+        prefix="img",
+    )
+    assert paths == [tmp_path / "img_0.png"]
+    assert (tmp_path / "img_0.png").read_bytes() == b"image-bytes"


### PR DESCRIPTION
## Summary
- group image outputs into timestamped `items/<category>_<tags>_<checkpoint>_<YYYYMMDD_HHMMSS>` folders and store folder URI in `image_path`
- allow `generate_image` to write images to a given directory using a prefix
- document new folder naming and clickable `image_path` behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68943596ccac83299b05b106b3318a2f