### PR TITLE
Autosave new rows in image editor

### DIFF
--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -149,6 +149,9 @@ def main() -> None:
         num_rows="dynamic",
         hide_index=True,
     )
+    if len(edited_df) > len(st.session_state.last_saved_df):
+        save_data(edited_df, CSV_FILE)
+        st.session_state.last_saved_df = edited_df.copy()
     st.session_state.image_df = edited_df
 
     prompt_col, gen_col, post_col, anal_col = st.columns(4)


### PR DESCRIPTION
## Summary
- autosave new rows from Streamlit data editor, saving to disk and session state when a row is added

## Testing
- `python - <<'PY' ... PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68943ee0a98c832995c512a0708edbfc