### PR TITLE
Ensure prompt-only responses

### DIFF
--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -180,6 +180,8 @@ def main() -> None:
                             f"Tags: {row.get('tags')}\n"
                             f"Base prompt (Japanese): {base}\n"
                             f"NSFW allowed: {nsfw}\n"
+                            "Return only the final English image-generation prompt.\n"
+                            "Do not include any explanations, notes, or reasoning text.\n"
                         )
                         prompt = generate_story_prompt(
                             synopsis,

--- a/movie_agent/ollama.py
+++ b/movie_agent/ollama.py
@@ -77,7 +77,8 @@ def generate_story_prompt(
     """
     if debug is None:
         debug = DEBUG_MODE
-    prompt = f"Generate a short story based on this context:\n{context}\n"
+    # Pass the context directly so any caller-provided instructions remain intact
+    prompt = context
     url = "http://localhost:11434/api/generate"
     payload: dict[str, object] = {
         "model": model,

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -48,11 +48,12 @@ def test_generate_story_prompt(monkeypatch):
         return FakeResponse()
 
     monkeypatch.setattr(requests, "post", fake_post)
-    result = generate_story_prompt("A synopsis", "phi3:mini")
+    context = "A synopsis"
+    result = generate_story_prompt(context, "phi3:mini")
     assert result == "Once upon a time"
     assert captured["json"] == {
         "model": "phi3:mini",
-        "prompt": "Generate a short story based on this context:\nA synopsis\n",
+        "prompt": context,
         "stream": False,
         "options": {"temperature": 0.8},
     }


### PR DESCRIPTION
## Summary
- Instruct image prompt generation to return only the final English image prompt without notes
- Pass caller-provided instructions directly to Ollama for prompt generation
- Update tests to reflect new prompt handling

## Testing
- `pytest -q`
- Simulated multiple row requests to `generate_story_prompt`

------
https://chatgpt.com/codex/tasks/task_e_689447888a18832985f82a39501d6b56