### PR TITLE
Validate numeric parameters before image generation

### DIFF
--- a/movie_agent/comfyui.py
+++ b/movie_agent/comfyui.py
@@ -22,6 +22,38 @@ DEFAULT_NEGATIVE_PROMPT = (
     "blurry, watermark, lowres, jpeg artifacts"
 )
 
+# Utility coercion helpers
+
+
+def _coerce_int(value, default, name, min_value=None):
+    """Convert ``value`` to int or return ``default`` and toast on error."""
+    if value in (None, ""):
+        return default
+    try:
+        value = int(value)
+    except (ValueError, TypeError):
+        st.toast(f"Invalid {name}; using default {default}")
+        return default
+    if min_value is not None and value < min_value:
+        st.toast(f"{name.capitalize()} must be >= {min_value}; using {default}")
+        return default
+    return value
+
+
+def _coerce_float(value, default, name, min_value=None):
+    """Convert ``value`` to float or return ``default`` and toast on error."""
+    if value in (None, ""):
+        return default
+    try:
+        value = float(value)
+    except (ValueError, TypeError):
+        st.toast(f"Invalid {name}; using default {default}")
+        return default
+    if min_value is not None and value < min_value:
+        st.toast(f"{name.capitalize()} must be >= {min_value}; using {default}")
+        return default
+    return value
+
 # Base workflow used for the ComfyUI /prompt API
 BASE_WORKFLOW = {
     "3": {
@@ -118,6 +150,12 @@ def generate_image(
     Returns a list of file paths for the saved images. If generation fails,
     an empty list is returned.
     """
+    seed = _coerce_int(seed, 0, "seed", min_value=0)
+    width = _coerce_int(width, DEFAULT_WIDTH, "width", min_value=1)
+    height = _coerce_int(height, DEFAULT_HEIGHT, "height", min_value=1)
+    cfg = _coerce_float(cfg, DEFAULT_CFG, "cfg", min_value=0)
+    steps = _coerce_int(steps, DEFAULT_STEPS, "steps", min_value=1)
+
     base = f"http://{COMFYUI_HOST}:{COMFYUI_PORT}"
     prompt_url = f"{base}/prompt"
 

--- a/tests/test_comfyui.py
+++ b/tests/test_comfyui.py
@@ -2,7 +2,7 @@ import json
 import time
 import requests
 
-from movie_agent.comfyui import list_comfy_models, generate_image
+import movie_agent.comfyui as comfyui
 
 
 def test_list_comfy_models(monkeypatch):
@@ -30,7 +30,7 @@ def test_list_comfy_models(monkeypatch):
         raise AssertionError(url)
 
     monkeypatch.setattr(requests, "get", fake_get)
-    ckpts, vaes, loras = list_comfy_models()
+    ckpts, vaes, loras = comfyui.list_comfy_models()
     assert ckpts == ["sd1"]
     assert vaes == ["", "vae1"]
     assert loras == ["", "lora1"]
@@ -71,7 +71,7 @@ def test_generate_image(monkeypatch, tmp_path):
     monkeypatch.setattr(requests, "get", fake_get)
     monkeypatch.setattr(time, "sleep", lambda x: None)
 
-    paths = generate_image(
+    paths = comfyui.generate_image(
         "p",
         "ckpt",
         "",
@@ -83,3 +83,62 @@ def test_generate_image(monkeypatch, tmp_path):
     )
     assert paths == [tmp_path / "img_0.png"]
     assert (tmp_path / "img_0.png").read_bytes() == b"image-bytes"
+
+
+def test_generate_image_invalid_numbers(monkeypatch, tmp_path):
+    class FakeResponse:
+        def __init__(self, data=None, content=b""):
+            self.status_code = 200
+            self._data = data
+            self.text = json.dumps(data) if data is not None else ""
+            self.content = content
+
+        def json(self):
+            return self._data
+
+        def raise_for_status(self):
+            pass
+
+    captured = {}
+
+    def fake_post(url, *args, **kwargs):
+        captured["json"] = kwargs.get("json")
+        return FakeResponse({"prompt_id": "abc"})
+
+    def fake_get(url, *args, **kwargs):
+        if url.endswith("/history/abc"):
+            return FakeResponse(
+                {
+                    "abc": {
+                        "outputs": {"9": {"images": [{"filename": "img.png"}]}}
+                    }
+                }
+            )
+        if url.endswith("/view"):
+            return FakeResponse(content=b"image-bytes")
+        raise AssertionError(url)
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(requests, "get", fake_get)
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    monkeypatch.setattr(comfyui.st, "toast", lambda msg: None)
+
+    comfyui.generate_image(
+        "p",
+        "ckpt",
+        "",
+        "badseed",
+        width="w",
+        height=None,
+        cfg="oops",
+        steps="n/a",
+        output_dir=tmp_path,
+        prefix="img",
+    )
+
+    payload = captured["json"]["prompt"]
+    assert payload["3"]["inputs"]["cfg"] == comfyui.DEFAULT_CFG
+    assert payload["3"]["inputs"]["steps"] == comfyui.DEFAULT_STEPS
+    assert payload["3"]["inputs"]["seed"] == 0
+    assert payload["5"]["inputs"]["width"] == comfyui.DEFAULT_WIDTH
+    assert payload["5"]["inputs"]["height"] == comfyui.DEFAULT_HEIGHT


### PR DESCRIPTION
## Summary
- validate and coerce user-provided generation settings, falling back to defaults with `st.toast` warnings
- mirror numeric validation inside ComfyUI `generate_image` to ensure safe defaults
- add regression tests for invalid numeric parameters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68944ad971f08329b0302eb6dcb33832