### PR TITLE
Add tests for WordPress posting payload

### DIFF
--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -1,0 +1,44 @@
+import json
+
+import pandas as pd
+import requests
+
+from movie_agent.image_ui import post_to_wordpress
+
+
+def test_post_to_wordpress(monkeypatch, tmp_path):
+    # create dummy images in temporary directory
+    img_b = tmp_path / "b.png"
+    img_b.write_bytes(b"second")
+    img_a = tmp_path / "a.png"
+    img_a.write_bytes(b"first")
+
+    captured = {}
+
+    class FakeResponse:
+        def __init__(self, data):
+            self.status_code = 200
+            self.text = json.dumps(data)
+
+        def raise_for_status(self):
+            pass
+
+    def fake_post(url, *args, **kwargs):
+        captured["payload"] = kwargs.get("json")
+        return FakeResponse({"url": "https://example.com/post/1"})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    row = pd.Series({"category": "cats", "tags": "cute,funny", "image_path": str(tmp_path)})
+    url = post_to_wordpress(row)
+    row["post_url"] = url
+
+    payload = captured["payload"]
+    # Title should incorporate category
+    assert payload["title"] == "毎日投稿AI生成画像 cats"
+    # Tags should be joined as a comma-separated string
+    assert payload["content"] == "cute, funny"
+    # Media should list images in sorted order
+    assert [m["filename"] for m in payload["media"]] == ["a.png", "b.png"]
+    # Returned URL should be recorded to post_url
+    assert row["post_url"] == "https://example.com/post/1"


### PR DESCRIPTION
## Summary
- add unit test for `post_to_wordpress` verifying title, tag content, media order, and stored URL

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68945c9e5d5c8329bcc3e211c94b2a9c