### PR TITLE
Handle Unicode filenames and optional image folder parts

### DIFF
--- a/movie_agent/csv_manager.py
+++ b/movie_agent/csv_manager.py
@@ -19,7 +19,7 @@ DEFAULT_VIDEO_LENGTH = 3
 def slugify(text: str) -> str:
     """Simplified slugify implementation."""
     text = text.lower().strip()
-    text = re.sub(r"[^a-z0-9]+", "_", text)
+    text = re.sub(r"[^\w.-]+", "_", text, flags=re.UNICODE)
     return text.strip("_") or "item"
 
 

--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -317,10 +317,15 @@ def main() -> None:
                 row.get("batch_count"), DEFAULT_BATCH, "batch_count", row_id, min_value=1
             )
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-            cat = slugify(str(row.get("category", "")))
-            tag_raw = str(row.get("tags", ""))
-            tag = slugify(tag_raw.replace(",", "_"))
-            folder = Path("items") / f"{cat}_{tag}_{checkpoint}_{timestamp}"
+            cat_raw = str(row.get("category", "")).strip()
+            tag_raw = str(row.get("tags", "")).replace(",", "_").strip()
+            parts = []
+            if cat_raw:
+                parts.append(slugify(cat_raw))
+            if tag_raw:
+                parts.append(slugify(tag_raw))
+            parts.extend([checkpoint, timestamp])
+            folder = Path("items") / "_".join(parts)
             folder.mkdir(parents=True, exist_ok=True)
 
             for b in range(batch):

--- a/tests/test_csv_manager.py
+++ b/tests/test_csv_manager.py
@@ -5,6 +5,7 @@ from movie_agent.csv_manager import (
     load_data,
     save_data,
     unique_path,
+    slugify,
     DEFAULT_MODEL,
     DEFAULT_MAX_TOKENS,
     DEFAULT_TEMPERATURE,
@@ -48,6 +49,11 @@ def test_unique_path(tmp_path):
     result2 = unique_path(str(base))
     assert result2.endswith("_2.txt")
     assert not os.path.exists(result2)
+
+
+def test_slugify_unicode():
+    assert slugify("テスト 日本語") == "テスト_日本語"
+    assert slugify("Hello 世界!!") == "hello_世界"
 
 
 def test_load_data_defaults_existing_file(tmp_path):


### PR DESCRIPTION
## Summary
- allow slugify to preserve Unicode characters like Japanese while cleaning filenames
- skip empty category/tag when creating image output folders
- test slugify with Unicode input

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689468d558788329a69401c282b8ec2d