### PR TITLE
Remove missing embeddings from default negative prompt

### DIFF
--- a/movie_agent/comfyui.py
+++ b/movie_agent/comfyui.py
@@ -17,10 +17,7 @@ DEFAULT_CFG = 7
 DEFAULT_STEPS = 28
 DEFAULT_WIDTH = 1024
 DEFAULT_HEIGHT = 1024
-DEFAULT_NEGATIVE_PROMPT = (
-    "embedding:BadDream:0.6, embedding:BadHandsV2:0.4, "
-    "blurry, watermark, lowres, jpeg artifacts"
-)
+DEFAULT_NEGATIVE_PROMPT = "blurry, watermark, lowres, jpeg artifacts"
 
 # Utility coercion helpers
 


### PR DESCRIPTION
## Summary
- Drop BadDream and BadHandsV2 embeddings from ComfyUI DEFAULT_NEGATIVE_PROMPT to avoid warnings about missing embeddings

## Testing
- `pytest`
- `python - <<'PY'
from movie_agent.comfyui import generate_image
result = generate_image('a test prompt', 'sdXL_v10VAEFix.safetensors', '', seed=1, output_dir='.', prefix='test', debug=True)
print('Result:', result)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68946f4928dc8329bfeea58381552d5f