### PR TITLE
Handle missing WordPress post URL

### DIFF
--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from pathlib import Path
 
 import base64
-import json
 from typing import Optional
 
 import requests
@@ -115,32 +114,25 @@ def post_to_wordpress(row: pd.Series) -> Optional[str]:
         "tags": tags_list,
     }
     try:
-        res = requests.post(WORDPRESS_API_URL, json=payload, timeout=10)
-        res.raise_for_status()
+        resp = requests.post(WORDPRESS_API_URL, json=payload, timeout=10)
+        resp.raise_for_status()
     except requests.HTTPError as e:
         st.error(f"WordPress投稿に失敗しました: {e}")
         return None
     except requests.RequestException as e:
         st.error(f"WordPress投稿に失敗しました: {e}")
         return None
-    if res.status_code not in (200, 201):
+    if resp.status_code not in (200, 201):
         st.error(
-            f"WordPress投稿に失敗しました: {res.status_code} {res.text}"
+            f"WordPress投稿に失敗しました: {resp.status_code} {resp.text}"
         )
         return None
-    try:
-        data = res.json()
-    except Exception:
-        try:
-            data = json.loads(res.text)
-        except Exception:
-            st.error(res.text)
-            return None
+    data = resp.json()
     url = data.get("url")
-    if not url:
-        st.error(data)
-        return None
-    return url
+    if url:
+        return url
+    st.warning("WordPressから投稿URLが返されませんでした")
+    return None
 
 
 def main() -> None:

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -24,6 +24,9 @@ def test_post_to_wordpress(monkeypatch, tmp_path):
         def raise_for_status(self):
             pass
 
+        def json(self):
+            return json.loads(self.text)
+
     def fake_post(url, *args, **kwargs):
         captured["payload"] = kwargs.get("json")
         return FakeResponse({"url": "https://example.com/post/1"})
@@ -92,3 +95,29 @@ def test_post_to_wordpress_bad_status(monkeypatch, tmp_path):
     row = pd.Series({"category": "cats", "tags": "cute", "image_path": str(tmp_path)})
     assert post_to_wordpress(row) is None
     assert errors and "WordPress投稿に失敗しました" in errors[0]
+
+
+def test_post_to_wordpress_no_url(monkeypatch, tmp_path):
+    img = tmp_path / "a.png"
+    img.write_bytes(b"first")
+
+    class FakeResponse:
+        status_code = 200
+        text = json.dumps({})
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {}
+
+    def fake_post(url, *args, **kwargs):
+        return FakeResponse()
+
+    warnings = []
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setattr(st, "warning", lambda msg: warnings.append(msg))
+
+    row = pd.Series({"category": "cats", "tags": "cute", "image_path": str(tmp_path)})
+    assert post_to_wordpress(row) is None
+    assert warnings and "WordPressから投稿URLが返されませんでした" in warnings[0]


### PR DESCRIPTION
## Summary
- Capture WordPress response JSON in `post_to_wordpress` and return the post URL when present.
- Warn and return `None` when WordPress does not provide a post URL.
- Add regression tests for missing post URL and refine existing mocks.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894958e28bc83299209a1f21fd13287