### PR TITLE
Add wordpress_site column to image spreadsheet handling

### DIFF
--- a/movie_agent/csv_manager.py
+++ b/movie_agent/csv_manager.py
@@ -168,6 +168,7 @@ def load_image_data(path: str) -> pd.DataFrame:
         "image_prompt",
         "image_path",
         "post_url",
+        "wordpress_site",
         "views_yesterday",
         "views_week",
         "views_month",
@@ -199,6 +200,7 @@ def load_image_data(path: str) -> pd.DataFrame:
         df["image_prompt"] = ""
         df["image_path"] = ""
         df["post_url"] = ""
+        df["wordpress_site"] = ""
         df["views_yesterday"] = 0
         df["views_week"] = 0
         df["views_month"] = 0
@@ -255,6 +257,7 @@ def load_image_data(path: str) -> pd.DataFrame:
         df["image_prompt"] = df["image_prompt"].fillna("").astype(str)
         df["image_path"] = df["image_path"].fillna("").astype(str)
         df["post_url"] = df["post_url"].fillna("").astype(str)
+        df["wordpress_site"] = df["wordpress_site"].fillna("").astype(str)
         for vcol in ["views_yesterday", "views_week", "views_month"]:
             df[vcol] = (
                 pd.to_numeric(df[vcol], errors="coerce").fillna(0).astype(int)

--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -172,6 +172,12 @@ def main() -> None:
         df.insert(idx, "llm_model", DEFAULT_MODEL)
     else:
         df["llm_model"] = df["llm_model"].fillna(DEFAULT_MODEL)
+
+    if "wordpress_site" not in df.columns:
+        idx = df.columns.get_loc("post_url") + 1 if "post_url" in df.columns else len(df.columns)
+        df.insert(idx, "wordpress_site", "")
+    else:
+        df["wordpress_site"] = df["wordpress_site"].fillna("")
     for col in ["checkpoint", "comfy_vae"]:
         if col not in df.columns:
             if col == "checkpoint":

--- a/tests/test_csv_manager.py
+++ b/tests/test_csv_manager.py
@@ -3,6 +3,7 @@ import pandas as pd
 
 from movie_agent.csv_manager import (
     load_data,
+    load_image_data,
     save_data,
     unique_path,
     slugify,
@@ -78,3 +79,10 @@ def test_load_data_defaults_existing_file(tmp_path):
     assert loaded.loc[0, "movie_prompt"] == ""
     assert loaded.loc[0, "batch_count"] == 1
     assert loaded.loc[0, "controlnet_image"] == ""
+
+
+def test_load_image_data_adds_wordpress_site(tmp_path):
+    path = tmp_path / "img.csv"
+    df = load_image_data(path)
+    assert "wordpress_site" in df.columns
+    assert df["wordpress_site"].eq("").all()


### PR DESCRIPTION
## Summary
- add `wordpress_site` field when loading image CSVs and ensure defaults
- initialize and preserve `wordpress_site` column in Streamlit UI
- cover `wordpress_site` default behavior with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895fdc5c6088329afb7e049519d8791