### PR TITLE
feat: warn when no posts selected

### DIFF
--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -405,6 +405,9 @@ def main() -> None:
     if post_col.button("Post"):
         df = st.session_state.image_df
         selected = df[df["selected"]]
+        if selected.empty:
+            st.warning("投稿する行を少なくとも1つ選択してください")
+            return
         selected_indices = selected.index.tolist()
         for idx in selected_indices:
             row = df.loc[idx]


### PR DESCRIPTION
## Summary
- add warning when attempting to post without any rows selected

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689619146ed083299b32069549b5e23e