### PR TITLE
Add WordPress posting debug logs

### DIFF
--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -128,8 +128,18 @@ def post_to_wordpress(row: pd.Series) -> Optional[str]:
     api_url = WORDPRESS_API_URL
     payload["site"] = site  # site key (not a full URL)
 
+    log_payload = {**payload, "media": [m["filename"] for m in media]}
+    print(f"[DEBUG] POST {api_url} with payload: {log_payload}")
+    st.write(f"POST {api_url} with payload: {log_payload}")
+
     try:
         resp = requests.post(api_url, json=payload, timeout=10)
+        print(
+            f"[DEBUG] WordPress response status: {resp.status_code}, body: {resp.text}"
+        )
+        st.write(
+            f"WordPress response status: {resp.status_code}, body: {resp.text}"
+        )
         resp.raise_for_status()
     except requests.HTTPError as e:
         st.error(f"WordPress投稿に失敗しました: {e}")
@@ -411,6 +421,9 @@ def main() -> None:
         selected_indices = selected.index.tolist()
         for idx in selected_indices:
             row = df.loc[idx]
+            info_msg = f"Processing row index {idx}: {row.to_dict()}"
+            print(info_msg)
+            st.write(info_msg)
             image_path = row.get("image_path", "")
             if not image_path or not os.path.exists(image_path):
                 st.warning(f"No image file for row {row.get('id', idx)}")


### PR DESCRIPTION
## Summary
- log each selected row before posting
- print WordPress payload and response status for easier debugging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68961a122a94832996c99859767a6c88