### PR TITLE
feat: track image post metadata

### DIFF
--- a/movie_agent/csv_manager.py
+++ b/movie_agent/csv_manager.py
@@ -167,7 +167,12 @@ def load_image_data(path: str) -> pd.DataFrame:
         "llm_model",
         "image_prompt",
         "image_path",
+        "post_id",
+        "media_id",
         "post_url",
+        "last_posted_at",
+        "version",
+        "error",
         "wordpress_site",
         "views_yesterday",
         "views_week",
@@ -199,7 +204,12 @@ def load_image_data(path: str) -> pd.DataFrame:
         df["llm_model"] = DEFAULT_MODEL
         df["image_prompt"] = ""
         df["image_path"] = ""
+        df["post_id"] = 0
+        df["media_id"] = 0
         df["post_url"] = ""
+        df["last_posted_at"] = ""
+        df["version"] = 0
+        df["error"] = ""
         df["wordpress_site"] = ""
         df["views_yesterday"] = 0
         df["views_week"] = 0
@@ -221,7 +231,14 @@ def load_image_data(path: str) -> pd.DataFrame:
         for c in missing_cols:
             if c in ["selected", "nsfw"]:
                 df[c] = False
-            elif c in ["views_yesterday", "views_week", "views_month"]:
+            elif c in [
+                "views_yesterday",
+                "views_week",
+                "views_month",
+                "post_id",
+                "media_id",
+                "version",
+            ]:
                 df[c] = 0
             else:
                 df[c] = ""
@@ -256,9 +273,18 @@ def load_image_data(path: str) -> pd.DataFrame:
         df["llm_model"] = df["llm_model"].fillna(DEFAULT_MODEL).astype(str)
         df["image_prompt"] = df["image_prompt"].fillna("").astype(str)
         df["image_path"] = df["image_path"].fillna("").astype(str)
+        df["post_id"] = pd.to_numeric(df["post_id"], errors="coerce").fillna(0).astype(int)
+        df["media_id"] = pd.to_numeric(df["media_id"], errors="coerce").fillna(0).astype(int)
         df["post_url"] = df["post_url"].fillna("").astype(str)
+        df["last_posted_at"] = df["last_posted_at"].fillna("").astype(str)
+        df["version"] = pd.to_numeric(df["version"], errors="coerce").fillna(0).astype(int)
+        df["error"] = df["error"].fillna("").astype(str)
         df["wordpress_site"] = df["wordpress_site"].fillna("").astype(str)
-        for vcol in ["views_yesterday", "views_week", "views_month"]:
+        for vcol in [
+            "views_yesterday",
+            "views_week",
+            "views_month",
+        ]:
             df[vcol] = (
                 pd.to_numeric(df[vcol], errors="coerce").fillna(0).astype(int)
             )

--- a/tests/test_csv_manager.py
+++ b/tests/test_csv_manager.py
@@ -32,11 +32,29 @@ def test_load_data_missing(tmp_path):
 
 def test_save_data(tmp_path):
     path = tmp_path / "out.csv"
-    df = pd.DataFrame({"selected": [True], "id": ["1"], "title": ["test"]})
+    df = pd.DataFrame(
+        {
+            "selected": [True],
+            "id": ["1"],
+            "title": ["test"],
+            "post_id": [123],
+            "media_id": [456],
+            "post_url": ["http://example.com"],
+            "last_posted_at": ["2024-01-01"],
+            "version": [1],
+            "error": ["oops"],
+        }
+    )
     save_data(df, path)
     loaded = pd.read_csv(path)
     assert "selected" not in loaded.columns
     assert str(loaded.loc[0, "id"]) == "1"
+    assert loaded.loc[0, "post_id"] == 123
+    assert loaded.loc[0, "media_id"] == 456
+    assert loaded.loc[0, "post_url"] == "http://example.com"
+    assert loaded.loc[0, "last_posted_at"] == "2024-01-01"
+    assert loaded.loc[0, "version"] == 1
+    assert loaded.loc[0, "error"] == "oops"
 
 
 def test_unique_path(tmp_path):
@@ -81,8 +99,23 @@ def test_load_data_defaults_existing_file(tmp_path):
     assert loaded.loc[0, "controlnet_image"] == ""
 
 
-def test_load_image_data_adds_wordpress_site(tmp_path):
+def test_load_image_data_adds_new_columns(tmp_path):
     path = tmp_path / "img.csv"
     df = load_image_data(path)
-    assert "wordpress_site" in df.columns
+    for col in [
+        "post_id",
+        "media_id",
+        "post_url",
+        "last_posted_at",
+        "version",
+        "error",
+        "wordpress_site",
+    ]:
+        assert col in df.columns
+    assert df["post_id"].eq(0).all()
+    assert df["media_id"].eq(0).all()
+    assert df["version"].eq(0).all()
+    assert df["post_url"].eq("").all()
+    assert df["last_posted_at"].eq("").all()
+    assert df["error"].eq("").all()
     assert df["wordpress_site"].eq("").all()


### PR DESCRIPTION
## Summary
- extend image CSV with posting metadata columns
- handle defaults and type casting for new columns
- verify saving and loading via updated tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689627ab93048329bbeb858f77916219