### PR TITLE
Normalize image CSV integers and streamline UI display

### DIFF
--- a/movie_agent/csv_manager.py
+++ b/movie_agent/csv_manager.py
@@ -34,6 +34,29 @@ def unique_path(path: str) -> str:
     return candidate
 
 
+def normalize_df(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize DataFrame types for image CSV handling.
+
+    Ensures numeric identifier and view count columns use nullable
+    integers and that the ``selected`` flag is a proper boolean.
+    """
+
+    int_cols = [
+        "post_id",
+        "media_id",
+        "version",
+        "views_yesterday",
+        "views_week",
+        "views_month",
+    ]
+    for col in int_cols:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce").astype("Int64")
+    if "selected" in df.columns:
+        df["selected"] = df["selected"].fillna(False).astype(bool)
+    return df
+
+
 def load_data(path: str) -> pd.DataFrame:
     """Load spreadsheet data from ``path``.
 
@@ -262,9 +285,7 @@ def load_image_data(path: str) -> pd.DataFrame:
             df["width"] = DEFAULT_WIDTH
         if "height" in missing_cols:
             df["height"] = DEFAULT_HEIGHT
-
         df = df[columns]
-        df["selected"] = df["selected"].fillna(False).astype(bool)
         df["nsfw"] = df["nsfw"].fillna(False).astype(bool)
         df["id"] = df["id"].astype(str)
         df["category"] = df["category"].fillna("").astype(str)
@@ -273,20 +294,10 @@ def load_image_data(path: str) -> pd.DataFrame:
         df["llm_model"] = df["llm_model"].fillna(DEFAULT_MODEL).astype(str)
         df["image_prompt"] = df["image_prompt"].fillna("").astype(str)
         df["image_path"] = df["image_path"].fillna("").astype(str)
-        df["post_id"] = pd.to_numeric(df["post_id"], errors="coerce").fillna(0).astype(int)
-        df["media_id"] = pd.to_numeric(df["media_id"], errors="coerce").fillna(0).astype(int)
         df["post_url"] = df["post_url"].fillna("").astype(str)
         df["last_posted_at"] = df["last_posted_at"].fillna("").astype(str)
-        df["version"] = pd.to_numeric(df["version"], errors="coerce").fillna(0).astype(int)
         df["error"] = df["error"].fillna("").astype(str)
         df["wordpress_site"] = df["wordpress_site"].fillna("").astype(str)
-        for vcol in [
-            "views_yesterday",
-            "views_week",
-            "views_month",
-        ]:
-            df[vcol] = (
-                pd.to_numeric(df[vcol], errors="coerce").fillna(0).astype(int)
-            )
+    df = normalize_df(df)
     return df
 

--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -29,6 +29,7 @@ from movie_agent.csv_manager import (
     DEFAULT_WIDTH,
     DEFAULT_HEIGHT,
     DEFAULT_SEED,
+    normalize_df,
 )
 
 # Parse CLI arguments passed after `--` when launching via Streamlit
@@ -310,6 +311,7 @@ def main() -> None:
             df[col] = default
         else:
             df[col] = df[col].fillna(default)
+    df = normalize_df(df)
     st.session_state.image_df = df
 
     st.write("### Image Spreadsheet")
@@ -327,12 +329,20 @@ def main() -> None:
             ),
             "image_prompt": st.column_config.TextColumn("Image Prompt"),
             "image_path": st.column_config.LinkColumn("Image Path"),
-            "post_id": st.column_config.TextColumn("Post ID"),
-            "media_id": st.column_config.TextColumn("Media ID"),
-            "post_url": st.column_config.TextColumn("Post URL"),
-            "last_posted_at": st.column_config.TextColumn("Last Posted At"),
-            "version": st.column_config.TextColumn("Version"),
-            "error": st.column_config.TextColumn("Error"),
+            "post_id": st.column_config.NumberColumn(
+                "Post ID", format="%d", step=1, disabled=True
+            ),
+            "media_id": st.column_config.NumberColumn(
+                "Media ID", format="%d", step=1, disabled=True
+            ),
+            "post_url": st.column_config.LinkColumn("Post URL", disabled=True),
+            "last_posted_at": st.column_config.TextColumn(
+                "Last Posted At", disabled=True
+            ),
+            "version": st.column_config.NumberColumn(
+                "Version", format="%d", step=1, disabled=True
+            ),
+            "error": st.column_config.TextColumn("Error", disabled=True),
             "views_yesterday": st.column_config.NumberColumn(
                 "Views Yesterday", min_value=0
             ),

--- a/tests/test_csv_manager.py
+++ b/tests/test_csv_manager.py
@@ -130,3 +130,30 @@ def test_load_image_data_defaults_existing(tmp_path):
     assert loaded.loc[0, "last_posted_at"] == ""
     assert loaded.loc[0, "version"] == 0
     assert loaded.loc[0, "error"] == ""
+
+
+def test_load_image_data_types(tmp_path):
+    path = tmp_path / "img.csv"
+    pd.DataFrame(
+        {
+            "post_id": ["1", ""],
+            "media_id": ["bad", 2],
+            "version": [pd.NA, 3],
+            "views_yesterday": [4, ""],
+            "views_week": ["5", "oops"],
+            "views_month": [6, None],
+            "selected": ["", True],
+        }
+    ).to_csv(path, index=False)
+    df = load_image_data(path)
+    for col in [
+        "post_id",
+        "media_id",
+        "version",
+        "views_yesterday",
+        "views_week",
+        "views_month",
+    ]:
+        assert str(df[col].dtype) == "Int64"
+    assert df["selected"].dtype == bool
+    assert bool(df.loc[0, "selected"]) is False


### PR DESCRIPTION
## Summary
- add `normalize_df` helper to coerce `post_id`, `media_id`, `version` and view counts to nullable integers and normalize `selected`
- normalize and lock image metadata columns before rendering Streamlit data editor
- test that `load_image_data` returns Int64 types and boolean `selected`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896a08f870483298ba15fdac47be02d