### PR TITLE
Adjust WordPress post title to include category and tag

### DIFF
--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -94,8 +94,10 @@ def rerun_with_message(message: str) -> None:
 def post_to_wordpress(row: pd.Series) -> Optional[str]:
     """Post image metadata and files to a WordPress server."""
 
-    title = f"毎日投稿AI生成画像 {row['category']}"
     tags_list = [t.strip() for t in row.get("tags", "").split(",") if t.strip()]
+    first_tag = tags_list[0] if tags_list else ""
+    title_parts = ["AI image", row.get("category", ""), first_tag]
+    title = " ".join([p for p in title_parts if p])
     content = ", ".join(tags_list)
     image_dir = Path(row.get("image_path", ""))
     if not image_dir.exists():

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -46,8 +46,8 @@ def test_post_to_wordpress(monkeypatch, tmp_path):
     row["post_url"] = url
 
     payload = captured["payload"]
-    # Title should incorporate category
-    assert payload["title"] == "毎日投稿AI生成画像 cats"
+    # Title should incorporate category and first tag
+    assert payload["title"] == "AI image cats cute"
     # Tags should be joined as a comma-separated string
     assert payload["content"] == "cute, funny"
     # Media should list images in sorted order


### PR DESCRIPTION
## Summary
- Update WordPress post title format to `AI image {category} {first_tag}`
- Align tests with the new title format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68982ba82adc83298374e91fc43a349b