### PR TITLE
Handle missing image metadata values

### DIFF
--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -95,11 +95,11 @@ def build_image_prompt_context(row: pd.Series) -> str:
     """Build the context string for image prompt generation."""
     base = row.get("ja_prompt", "")
     nsfw = bool(row.get("nsfw"))
-    language = row.get("id")
+    language = str(row.get("id") or "").strip()
     synopsis = (
         "Create an English image-generation prompt.\n"
-        f"Category: {row.get('category')}\n"
-        f"Tags: {row.get('tags')}\n"
+        f"Category: {str(row.get('category') or '')}\n"
+        f"Tags: {str(row.get('tags') or '')}\n"
         f"Base prompt (Japanese): {base}\n"
         f"NSFW allowed: {nsfw}\n"
         "Return only the final English image-generation prompt.\n"

--- a/tests/test_image_prompt_language.py
+++ b/tests/test_image_prompt_language.py
@@ -15,3 +15,16 @@ def test_build_image_prompt_context_includes_language_hint_and_ethnic_instructio
         "Ensure the prompt depicts people whose appearance reflects typical traits of regions where this language is primarily spoken."
         in result
     )
+
+
+def test_build_image_prompt_context_omits_language_hint_if_id_missing():
+    row = pd.Series(
+        {
+            "ja_prompt": "テストプロンプト",
+            "nsfw": False,
+            "category": "風景",
+            "tags": "自然",
+        }
+    )
+    result = build_image_prompt_context(row)
+    assert "Language hint:" not in result


### PR DESCRIPTION
## Summary
- Prevent NaN values from entering image prompt context by stringifying metadata fields and language ID
- Add regression test ensuring language hint isn't emitted when ID missing

## Testing
- `pytest tests/test_image_prompt_language.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689883d732948329884d32d6eceda7f4