### PR TITLE
Add weekly and monthly view analysis

### DIFF
--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -483,14 +483,20 @@ def main() -> None:
                 )
                 continue
             try:
-                res = requests.get(
-                    f"{AUTOPOSTER_API_URL}/wordpress/stats/views",
-                    params={"site": site, "post_id": post_id, "days": 1},
-                    timeout=10,
-                )
-                res.raise_for_status()
-                data = res.json()
-                df.at[idx, "views_yesterday"] = data.get("views", [0])[0]
+                for days, column in [
+                    (1, "views_yesterday"),
+                    (7, "views_week"),
+                    (30, "views_month"),
+                ]:
+                    res = requests.get(
+                        f"{AUTOPOSTER_API_URL}/wordpress/stats/views",
+                        params={"site": site, "post_id": post_id, "days": days},
+                        timeout=10,
+                    )
+                    res.raise_for_status()
+                    data = res.json()
+                    views = data.get("views", [])
+                    df.at[idx, column] = views[0] if views else 0
             except Exception as e:
                 st.error(
                     f"Analysis failed for row {row.get('id', idx)}: {e}"

--- a/tests/test_analysis_views.py
+++ b/tests/test_analysis_views.py
@@ -44,3 +44,114 @@ def test_analysis_updates_views(monkeypatch):
         st.session_state.image_df.at[idx, "views_yesterday"] = data.get("views", [0])[0]
 
     assert st.session_state.image_df.at[0, "views_yesterday"] == 5
+
+
+def test_analysis_updates_week_and_month_views(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "selected": True,
+                "post_site": "mysite",
+                "post_id": 10,
+                "views_yesterday": 0,
+                "views_week": 0,
+                "views_month": 0,
+            }
+        ]
+    )
+    st.session_state.image_df = df
+
+    class FakeResponse:
+        def __init__(self, views):
+            self._views = views
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"views": self._views}
+
+    def fake_get(url, params=None, timeout=10):
+        days = params.get("days")
+        if days == 1:
+            return FakeResponse([5])
+        if days == 7:
+            return FakeResponse([50])
+        if days == 30:
+            return FakeResponse([300])
+        return FakeResponse([])
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    selected = st.session_state.image_df[st.session_state.image_df["selected"]]
+    for idx, row in selected.iterrows():
+        site = row.get("post_site", "")
+        post_id = row.get("post_id", "")
+        for days, col in [
+            (1, "views_yesterday"),
+            (7, "views_week"),
+            (30, "views_month"),
+        ]:
+            res = requests.get(
+                f"{AUTOPOSTER_API_URL}/wordpress/stats/views",
+                params={"site": site, "post_id": post_id, "days": days},
+                timeout=10,
+            )
+            res.raise_for_status()
+            data = res.json()
+            views = data.get("views", [])
+            st.session_state.image_df.at[idx, col] = views[0] if views else 0
+
+    assert st.session_state.image_df.at[0, "views_week"] == 50
+    assert st.session_state.image_df.at[0, "views_month"] == 300
+
+
+def test_analysis_handles_empty_views(monkeypatch):
+    df = pd.DataFrame(
+        [
+            {
+                "selected": True,
+                "post_site": "mysite",
+                "post_id": 10,
+                "views_yesterday": 1,
+                "views_week": 1,
+                "views_month": 1,
+            }
+        ]
+    )
+    st.session_state.image_df = df
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"views": []}
+
+    def fake_get(url, params=None, timeout=10):
+        return FakeResponse()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    selected = st.session_state.image_df[st.session_state.image_df["selected"]]
+    for idx, row in selected.iterrows():
+        site = row.get("post_site", "")
+        post_id = row.get("post_id", "")
+        for days, col in [
+            (1, "views_yesterday"),
+            (7, "views_week"),
+            (30, "views_month"),
+        ]:
+            res = requests.get(
+                f"{AUTOPOSTER_API_URL}/wordpress/stats/views",
+                params={"site": site, "post_id": post_id, "days": days},
+                timeout=10,
+            )
+            res.raise_for_status()
+            data = res.json()
+            views = data.get("views", [])
+            st.session_state.image_df.at[idx, col] = views[0] if views else 0
+
+    assert st.session_state.image_df.at[0, "views_yesterday"] == 0
+    assert st.session_state.image_df.at[0, "views_week"] == 0
+    assert st.session_state.image_df.at[0, "views_month"] == 0


### PR DESCRIPTION
## Summary
- Extend analysis to fetch 7-day and 30-day view counts and store them in `views_week` and `views_month`
- Default view counts to 0 when API returns an empty list
- Add unit tests covering weekly/monthly stats and empty-view handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689884fdb9408329b641bfa0358284ee