### PR TITLE
docs: document post_site and post_id columns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,13 +95,13 @@ streamlit run movie_agent/app.py
 `image_ui.py` は画像投稿用の Streamlit UI です。カテゴリ・タグ・NSFW フラグを管理し、日本語 `ja_prompt` を **Ollama** で英訳、**ComfyUI** で画像生成し、`autoPoster` API で自動投稿します。投稿後はビュー数を取得して記録できます。動画 UI と同じ Streamlit バージョンで動作するため、アップグレードは不要です。
 
 ### 必須列
-`category`, `tags`, `nsfw`, `ja_prompt`, `llm_model`, `image_prompt`, `image_path`, `post_url`, `views_yesterday`, `views_week`, `views_month` が最低限必要です。`llm_model` は英語プロンプト生成に使用する Ollama モデルを指定し、デフォルトは `gpt-oss:20b` です。シートでは `image_prompt` 列の前に配置してください。既存の LLM / ComfyUI パラメータ列も併用できます。
+`category`, `tags`, `nsfw`, `ja_prompt`, `llm_model`, `image_prompt`, `image_path`, `post_url`, `post_site`, `post_id`, `views_yesterday`, `views_week`, `views_month` が最低限必要です。`post_site` と `post_id` は投稿後に自動で記録され、`Analysis` ボタンで視聴数を取得する際に利用します。`llm_model` は英語プロンプト生成に使用する Ollama モデルを指定し、デフォルトは `gpt-oss:20b` です。シートでは `image_prompt` 列の前に配置してください。既存の LLM / ComfyUI パラメータ列も併用できます。
 
 ### ボタン
 - **Generate prompt** – `ja_prompt` を英語 `image_prompt` へ変換
 - **Generate images** – ComfyUI で画像生成。生成された画像は `items/<category>_<tags>_<checkpoint>_<YYYYMMDD_HHMMSS>/` というタイムスタンプ付きフォルダに保存され、`image_path` 列にはそのフォルダの絶対パス (`file://...`) がクリック可能なリンクとして記録されます。
 - **Post** – autoPoster へ投稿
-- **Analysis** – autoPoster から視聴数取得
+- **Analysis** – `post_site` と `post_id` を用いて autoPoster から視聴数取得
 
 ### 実行方法
 Windows では以下のバッチで起動できます。

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Include the following columns in your sheet:
 - `image_prompt`
 - `image_path`
 - `post_url`
+- `post_site`
+- `post_id`
 - `wordpress_site`
 - `views_yesterday`
 - `views_week`
@@ -160,13 +162,15 @@ Include the following columns in your sheet:
 Place this column before `image_prompt`; the default model is `gpt-oss:20b`.
 Additional LLM or ComfyUI parameter columns (model, temperature, steps, seed, width, height, etc.) may also be added.
 
+`post_site` and `post_id` store the site slug and post identifier returned after posting. The Analysis button uses them to look up view counts.
+
 `wordpress_site` specifies which WordPress site to post to; you can supply a site slug or a full API URL. For example, `mysite`.
 
 ### Button actions
 - **Generate prompt** – use Ollama to convert `ja_prompt` into an English `image_prompt`.
 - **Generate images** – call ComfyUI to create images in a timestamped folder named `items/<category>_<tags>_<checkpoint>_<YYYYMMDD_HHMMSS>/`. The `image_path` column stores a `file://` URI to this folder, which Streamlit renders as a clickable link.
 - **Post** – send images to the configured WordPress API and store the resulting `post_url`.
-- **Analysis** – query the `autoPoster` API to fill `views_yesterday`, `views_week`, and `views_month`.
+- **Analysis** – use `post_site` and `post_id` to query the `autoPoster` API and fill `views_yesterday`, `views_week`, and `views_month`.
 
 ### Running
 On Windows you can launch the UI with the helper scripts:


### PR DESCRIPTION
## Summary
- document new post_site and post_id columns in README and AGENTS
- clarify that Analysis uses these columns when fetching view counts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898877c976c8329897e3ac9b1712495