### PR TITLE
Add wordpress account column for posting

### DIFF
--- a/images.csv
+++ b/images.csv
@@ -1,1 +1,1 @@
-id,category,tags,nsfw,ja_prompt,llm_model,image_prompt,image_path,post_url,post_site,post_id,wordpress_site,views_yesterday,views_week,views_month,checkpoint,comfy_vae,comfy_lora,temperature,max_tokens,top_p,cfg,steps,seed,batch_count,width,height
+id,category,tags,nsfw,ja_prompt,llm_model,image_prompt,image_path,post_url,post_site,post_id,wordpress_site,wordpress_account,views_yesterday,views_week,views_month,checkpoint,comfy_vae,comfy_lora,temperature,max_tokens,top_p,cfg,steps,seed,batch_count,width,height

--- a/movie_agent/csv_manager.py
+++ b/movie_agent/csv_manager.py
@@ -14,6 +14,7 @@ DEFAULT_WIDTH = 1024
 DEFAULT_HEIGHT = 1024
 DEFAULT_FPS = 24
 DEFAULT_VIDEO_LENGTH = 3
+WORDPRESS_ACCOUNT = os.getenv("WORDPRESS_ACCOUNT", "")
 
 
 def slugify(text: str) -> str:
@@ -171,6 +172,7 @@ def load_image_data(path: str) -> pd.DataFrame:
         "post_site",
         "post_id",
         "wordpress_site",
+        "wordpress_account",
         "views_yesterday",
         "views_week",
         "views_month",
@@ -205,6 +207,7 @@ def load_image_data(path: str) -> pd.DataFrame:
         df["post_site"] = ""
         df["post_id"] = ""
         df["wordpress_site"] = ""
+        df["wordpress_account"] = WORDPRESS_ACCOUNT
         df["views_yesterday"] = 0
         df["views_week"] = 0
         df["views_month"] = 0
@@ -227,6 +230,8 @@ def load_image_data(path: str) -> pd.DataFrame:
                 df[c] = False
             elif c in ["views_yesterday", "views_week", "views_month"]:
                 df[c] = 0
+            elif c == "wordpress_account":
+                df[c] = WORDPRESS_ACCOUNT
             else:
                 df[c] = ""
         if "llm_model" in missing_cols:
@@ -264,6 +269,7 @@ def load_image_data(path: str) -> pd.DataFrame:
         df["post_site"] = df["post_site"].fillna("").astype(str)
         df["post_id"] = df["post_id"].fillna("").astype(str)
         df["wordpress_site"] = df["wordpress_site"].fillna("").astype(str)
+        df["wordpress_account"] = df["wordpress_account"].fillna(WORDPRESS_ACCOUNT).astype(str)
         for vcol in ["views_yesterday", "views_week", "views_month"]:
             df[vcol] = (
                 pd.to_numeric(df[vcol], errors="coerce").fillna(0).astype(int)

--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -141,8 +141,8 @@ def post_to_wordpress(row: pd.Series) -> Optional[Dict[str, Any]]:
                 encoded = base64.b64encode(f.read()).decode("utf-8")
             media.append({"filename": p.name, "data": encoded})
 
-    # Use the same site key for the posting account.
-    account = (row.get("wordpress_site") or WORDPRESS_ACCOUNT or "nicchi").strip()
+    # Determine posting account from row or environment variable.
+    account = (row.get("wordpress_account") or WORDPRESS_ACCOUNT or "nicchi").strip()
     payload = {
         "account": account,
         "title": title,
@@ -240,6 +240,11 @@ def main() -> None:
         df.insert(idx, "wordpress_site", "")
     else:
         df["wordpress_site"] = df["wordpress_site"].fillna("")
+    if "wordpress_account" not in df.columns:
+        idx = df.columns.get_loc("wordpress_site") + 1
+        df.insert(idx, "wordpress_account", WORDPRESS_ACCOUNT)
+    else:
+        df["wordpress_account"] = df["wordpress_account"].fillna(WORDPRESS_ACCOUNT)
     # "wordpress_site" values are keys, not full URLs.
     for col in ["checkpoint", "comfy_vae"]:
         if col not in df.columns:

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -40,6 +40,7 @@ def test_post_to_wordpress(monkeypatch, tmp_path):
             "tags": "cute,funny",
             "image_path": str(tmp_path),
             "wordpress_site": "mysite",
+            "wordpress_account": "myacct",
         }
     )
     result = post_to_wordpress(row)
@@ -63,6 +64,7 @@ def test_post_to_wordpress(monkeypatch, tmp_path):
     assert [m["filename"] for m in payload["media"]] == ["a.png", "b.png"]
     # Site should be forwarded in payload
     assert payload["site"] == "mysite"
+    assert payload["account"] == "myacct"
     # Returned values should be recorded
     assert row["post_url"] == "https://example.com/post/10"
     assert row["post_site"] == "mysite"
@@ -98,6 +100,7 @@ def test_post_to_wordpress_payload_has_site(monkeypatch, tmp_path):
             "tags": "cute",
             "image_path": str(tmp_path),
             "wordpress_site": "mysite",
+            "wordpress_account": "myacct",
         }
     )
 
@@ -137,6 +140,7 @@ def test_post_to_wordpress_records_site_and_id(monkeypatch, tmp_path):
                 "tags": "cute",
                 "image_path": str(tmp_path),
                 "wordpress_site": "mysite",
+                "wordpress_account": "myacct",
             }
         ]
     )
@@ -175,6 +179,7 @@ def test_post_to_wordpress_http_error(monkeypatch, tmp_path):
             "tags": "cute",
             "image_path": str(tmp_path),
             "wordpress_site": "mysite",
+            "wordpress_account": "myacct",
         }
     )
     assert post_to_wordpress(row) is None
@@ -208,6 +213,7 @@ def test_post_to_wordpress_bad_status(monkeypatch, tmp_path):
             "tags": "cute",
             "image_path": str(tmp_path),
             "wordpress_site": "mysite",
+            "wordpress_account": "myacct",
         }
     )
     assert post_to_wordpress(row) is None
@@ -241,6 +247,7 @@ def test_post_to_wordpress_no_url(monkeypatch, tmp_path):
             "tags": "cute",
             "image_path": str(tmp_path),
             "wordpress_site": "mysite",
+            "wordpress_account": "myacct",
         }
     )
     assert post_to_wordpress(row) is None
@@ -259,6 +266,11 @@ def test_post_to_wordpress_missing_site(monkeypatch, tmp_path):
         lambda *a, **k: pytest.fail("post should not be called when site missing"),
     )
 
-    row = pd.Series({"category": "cats", "tags": "cute", "image_path": str(tmp_path)})
+    row = pd.Series({
+        "category": "cats",
+        "tags": "cute",
+        "image_path": str(tmp_path),
+        "wordpress_account": "myacct",
+    })
     assert post_to_wordpress(row) is None
     assert errors and "WordPressサイトが指定されていません" in errors[0]


### PR DESCRIPTION
## Summary
- add `wordpress_account` column to image CSV and loader with env fallback
- allow `post_to_wordpress` to read account from row or env var
- test WordPress posting uses provided account

## Testing
- `pytest tests/test_wordpress_post.py`


------
https://chatgpt.com/codex/tasks/task_e_6898898d090c83299a90d016f743431d