### PR TITLE
Require explicit WordPress account before posting

### DIFF
--- a/movie_agent/csv_manager.py
+++ b/movie_agent/csv_manager.py
@@ -14,7 +14,6 @@ DEFAULT_WIDTH = 1024
 DEFAULT_HEIGHT = 1024
 DEFAULT_FPS = 24
 DEFAULT_VIDEO_LENGTH = 3
-WORDPRESS_ACCOUNT = os.getenv("WORDPRESS_ACCOUNT", "")
 
 
 def slugify(text: str) -> str:
@@ -207,7 +206,7 @@ def load_image_data(path: str) -> pd.DataFrame:
         df["post_site"] = ""
         df["post_id"] = ""
         df["wordpress_site"] = ""
-        df["wordpress_account"] = WORDPRESS_ACCOUNT
+        df["wordpress_account"] = ""
         df["views_yesterday"] = 0
         df["views_week"] = 0
         df["views_month"] = 0
@@ -231,7 +230,7 @@ def load_image_data(path: str) -> pd.DataFrame:
             elif c in ["views_yesterday", "views_week", "views_month"]:
                 df[c] = 0
             elif c == "wordpress_account":
-                df[c] = WORDPRESS_ACCOUNT
+                df[c] = ""
             else:
                 df[c] = ""
         if "llm_model" in missing_cols:
@@ -269,7 +268,7 @@ def load_image_data(path: str) -> pd.DataFrame:
         df["post_site"] = df["post_site"].fillna("").astype(str)
         df["post_id"] = df["post_id"].fillna("").astype(str)
         df["wordpress_site"] = df["wordpress_site"].fillna("").astype(str)
-        df["wordpress_account"] = df["wordpress_account"].fillna(WORDPRESS_ACCOUNT).astype(str)
+        df["wordpress_account"] = df["wordpress_account"].fillna("").astype(str)
         for vcol in ["views_yesterday", "views_week", "views_month"]:
             df[vcol] = (
                 pd.to_numeric(df[vcol], errors="coerce").fillna(0).astype(int)

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -274,3 +274,52 @@ def test_post_to_wordpress_missing_site(monkeypatch, tmp_path):
     })
     assert post_to_wordpress(row) is None
     assert errors and "WordPressサイトが指定されていません" in errors[0]
+
+
+def test_post_to_wordpress_missing_account(monkeypatch, tmp_path):
+    img = tmp_path / "a.png"
+    img.write_bytes(b"first")
+
+    errors = []
+    monkeypatch.setattr(st, "error", lambda msg: errors.append(msg))
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *a, **k: pytest.fail("post should not be called when account missing"),
+    )
+
+    row = pd.Series(
+        {
+            "category": "cats",
+            "tags": "cute",
+            "image_path": str(tmp_path),
+            "wordpress_site": "mysite",
+        }
+    )
+    assert post_to_wordpress(row) is None
+    assert errors and "WordPressアカウントが指定されていません" in errors[0]
+
+
+def test_post_to_wordpress_empty_account(monkeypatch, tmp_path):
+    img = tmp_path / "a.png"
+    img.write_bytes(b"first")
+
+    errors = []
+    monkeypatch.setattr(st, "error", lambda msg: errors.append(msg))
+    monkeypatch.setattr(
+        requests,
+        "post",
+        lambda *a, **k: pytest.fail("post should not be called when account empty"),
+    )
+
+    row = pd.Series(
+        {
+            "category": "cats",
+            "tags": "cute",
+            "image_path": str(tmp_path),
+            "wordpress_site": "mysite",
+            "wordpress_account": "",
+        }
+    )
+    assert post_to_wordpress(row) is None
+    assert errors and "WordPressアカウントが指定されていません" in errors[0]


### PR DESCRIPTION
## Summary
- Skip WordPress posting when no `wordpress_account` is provided
- Remove default account population in CSV handling
- Cover missing/empty account scenarios with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a91602548329bbe1def327cff18e