### PR TITLE
Extend negative prompt filtering in ComfyUI

### DIFF
--- a/movie_agent/comfyui.py
+++ b/movie_agent/comfyui.py
@@ -17,7 +17,10 @@ DEFAULT_CFG = 7
 DEFAULT_STEPS = 28
 DEFAULT_WIDTH = 1024
 DEFAULT_HEIGHT = 1024
-DEFAULT_NEGATIVE_PROMPT = "blurry, watermark, lowres, jpeg artifacts"
+DEFAULT_NEGATIVE_PROMPT = (
+    "blurry, watermark, lowres, jpeg artifacts, nsfw, nipples, "
+    "pubic hair, nude, exposed chest"
+)
 
 # Utility coercion helpers
 
@@ -97,6 +100,9 @@ BASE_WORKFLOW = {
         "inputs": {"filename_prefix": "ComfyUI", "images": ["8", 0]},
     },
 }
+
+# Ensure the base workflow always uses the current negative prompt
+BASE_WORKFLOW["7"]["inputs"]["text"] = DEFAULT_NEGATIVE_PROMPT
 
 
 def list_comfy_models() -> tuple[list[str], list[str], list[str]]:


### PR DESCRIPTION
## Summary
- broaden DEFAULT_NEGATIVE_PROMPT to block explicit elements like nipples or exposed chest
- ensure BASE_WORKFLOW uses the updated negative prompt for every request

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689954e90a848329a89464b45e9f0fb6