### PR TITLE
Add negative prompt support to image generation

### DIFF
--- a/images.csv
+++ b/images.csv
@@ -1,1 +1,1 @@
-id,category,tags,nsfw,ja_prompt,llm_model,image_prompt,image_path,post_url,post_site,post_id,wordpress_site,wordpress_account,views_yesterday,views_week,views_month,checkpoint,comfy_vae,comfy_lora,temperature,max_tokens,top_p,cfg,steps,seed,batch_count,width,height
+id,category,tags,nsfw,ja_prompt,llm_model,image_prompt,negative_prompt,image_path,post_url,post_site,post_id,wordpress_site,wordpress_account,views_yesterday,views_week,views_month,checkpoint,comfy_vae,comfy_lora,temperature,max_tokens,top_p,cfg,steps,seed,batch_count,width,height

--- a/movie_agent/comfyui.py
+++ b/movie_agent/comfyui.py
@@ -139,6 +139,7 @@ def generate_image(
     checkpoint: str,
     vae: str,
     seed: int,
+    negative_prompt: str = DEFAULT_NEGATIVE_PROMPT,
     width: int = DEFAULT_WIDTH,
     height: int = DEFAULT_HEIGHT,
     cfg: float = DEFAULT_CFG,
@@ -150,6 +151,7 @@ def generate_image(
 ) -> List[Path]:
     """Generate image(s) via ComfyUI and save to ``output_dir``.
 
+    ``negative_prompt`` overrides the default when provided.
     Returns a list of file paths for the saved images. If generation fails,
     an empty list is returned.
     """
@@ -164,6 +166,7 @@ def generate_image(
 
     workflow = json.loads(json.dumps(BASE_WORKFLOW))
     workflow["6"]["inputs"]["text"] = prompt
+    workflow["7"]["inputs"]["text"] = negative_prompt or DEFAULT_NEGATIVE_PROMPT
     workflow["4"]["inputs"]["ckpt_name"] = checkpoint
     if vae:
         workflow["4"]["inputs"]["vae_name"] = vae

--- a/movie_agent/csv_manager.py
+++ b/movie_agent/csv_manager.py
@@ -166,6 +166,7 @@ def load_image_data(path: str) -> pd.DataFrame:
         "ja_prompt",
         "llm_model",
         "image_prompt",
+        "negative_prompt",
         "image_path",
         "post_url",
         "post_site",
@@ -201,6 +202,7 @@ def load_image_data(path: str) -> pd.DataFrame:
         df["ja_prompt"] = ""
         df["llm_model"] = DEFAULT_MODEL
         df["image_prompt"] = ""
+        df["negative_prompt"] = ""
         df["image_path"] = ""
         df["post_url"] = ""
         df["post_site"] = ""
@@ -263,6 +265,7 @@ def load_image_data(path: str) -> pd.DataFrame:
         df["ja_prompt"] = df["ja_prompt"].fillna("").astype(str)
         df["llm_model"] = df["llm_model"].fillna(DEFAULT_MODEL).astype(str)
         df["image_prompt"] = df["image_prompt"].fillna("").astype(str)
+        df["negative_prompt"] = df["negative_prompt"].fillna("").astype(str)
         df["image_path"] = df["image_path"].fillna("").astype(str)
         df["post_url"] = df["post_url"].fillna("").astype(str)
         df["post_site"] = df["post_site"].fillna("").astype(str)

--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -16,6 +16,7 @@ from movie_agent.comfyui import (
     generate_image,
     DEFAULT_CFG,
     DEFAULT_STEPS,
+    DEFAULT_NEGATIVE_PROMPT,
 )
 from movie_agent.ollama import (
     list_ollama_models,
@@ -316,6 +317,7 @@ def main() -> None:
                 "LLM Model", options=st.session_state.models
             ),
             "image_prompt": st.column_config.TextColumn("Image Prompt"),
+            "negative_prompt": st.column_config.TextColumn("Negative Prompt"),
             "image_path": st.column_config.LinkColumn("Image Path"),
             "post_url": st.column_config.TextColumn("Post URL"),
             "post_site": st.column_config.TextColumn("Post Site"),
@@ -409,6 +411,7 @@ def main() -> None:
             if not prompt:
                 st.warning(f"No image_prompt for row {row.get('id', idx)}")
                 continue
+            neg_prompt = row.get("negative_prompt", "") or DEFAULT_NEGATIVE_PROMPT
             checkpoint = row.get("checkpoint") or ""
             if not checkpoint:
                 if st.session_state.comfy_models:
@@ -456,6 +459,7 @@ def main() -> None:
                         checkpoint=checkpoint,
                         vae=vae,
                         seed=seed + b,
+                        negative_prompt=neg_prompt,
                         width=width_val,
                         height=height_val,
                         cfg=cfg_val,

--- a/tests/test_csv_manager.py
+++ b/tests/test_csv_manager.py
@@ -90,3 +90,5 @@ def test_load_image_data_adds_post_columns(tmp_path):
     assert df["post_id"].eq("").all()
     assert "wordpress_site" in df.columns
     assert df["wordpress_site"].eq("").all()
+    assert "negative_prompt" in df.columns
+    assert df["negative_prompt"].eq("").all()


### PR DESCRIPTION
## Summary
- Allow ComfyUI image generation to accept a custom negative prompt
- Extend image UI to edit and pass negative prompts per row
- Preserve negative prompts when loading/saving CSV data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689959e20944832984893c69b3aab435