### PR TITLE
Add LM Studio API helpers and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ start_image_ui_conda.bat
 
 ### 環境変数の例
 - `OLLAMA_HOST` = Ollama API (例: http://localhost:11434)
+- `LMSTUDIO_HOST` = LM Studio API (例: http://localhost:1234)
 - `COMFYUI_API_URL` = ComfyUI REST API (例: http://127.0.0.1:8188)
 - `AUTOPOSTER_API_URL` = autoPoster サービス (例: http://127.0.0.1:9000)
 - `WORDPRESS_API_URL` = WordPress REST API (例: http://127.0.0.1:8000/wp-json)

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ streamlit run movie_agent/image_ui.py
 Set endpoints so the UI can reach local services:
 
 - `OLLAMA_HOST` – base URL of the Ollama API (e.g. `http://localhost:11434`).
+- `LMSTUDIO_HOST` – base URL of the LM Studio API (e.g. `http://localhost:1234`).
 - `COMFYUI_API_URL` – endpoint for the ComfyUI REST API (e.g. `http://127.0.0.1:8188`).
 - `AUTOPOSTER_API_URL` – URL of the local autoPoster service for analytics (e.g. `http://127.0.0.1:9000`).
 - `WORDPRESS_API_URL` – endpoint for posting to WordPress (e.g. `http://localhost:8765/wordpress/post`).

--- a/movie_agent/lmstudio.py
+++ b/movie_agent/lmstudio.py
@@ -1,0 +1,67 @@
+"""Helpers for interacting with a local LM Studio server.
+
+This module provides thin wrappers around LM Studio's OpenAI-compatible API.
+The base URL is read from the ``LMSTUDIO_HOST`` environment variable and
+defaults to ``http://localhost:1234``.
+"""
+
+from __future__ import annotations
+
+import os
+import requests
+import streamlit as st
+
+
+def _base_url() -> str:
+    """Return the base URL for LM Studio from the environment."""
+    return os.environ.get("LMSTUDIO_HOST", "http://localhost:1234").rstrip("/")
+
+
+def list_lmstudio_models(timeout: int | None = 30) -> list[str]:
+    """Fetch available models from the LM Studio server."""
+    url = f"{_base_url()}/v1/models"
+    try:
+        res = requests.get(url, timeout=timeout)
+        res.raise_for_status()
+        data = res.json()
+        return [m.get("id", "") for m in data.get("data", []) if m.get("id")]
+    except requests.exceptions.RequestException as e:
+        st.error(f"LM Studio API error: {e}")
+    except ValueError as e:
+        st.error(f"Invalid response from LM Studio: {e}")
+    return []
+
+
+def generate_story_prompt_lmstudio(
+    context: str,
+    model: str,
+    temperature: float = 0.8,
+    max_tokens: int | None = None,
+    top_p: float | None = None,
+    timeout: int = 300,
+) -> str | None:
+    """Generate text using LM Studio's chat completions API."""
+
+    url = f"{_base_url()}/v1/chat/completions"
+    payload: dict[str, object] = {
+        "model": model,
+        "messages": [{"role": "user", "content": context}],
+        "temperature": temperature,
+    }
+    if max_tokens is not None:
+        payload["max_tokens"] = max_tokens
+    if top_p is not None:
+        payload["top_p"] = top_p
+
+    try:
+        res = requests.post(url, json=payload, timeout=timeout)
+        res.raise_for_status()
+        data = res.json()
+        return data["choices"][0]["message"]["content"]
+    except (requests.exceptions.RequestException, KeyError, IndexError, ValueError) as e:
+        st.error(f"LM Studio API error: {e}")
+        return None
+
+
+__all__ = ["list_lmstudio_models", "generate_story_prompt_lmstudio"]
+

--- a/tests/test_lmstudio.py
+++ b/tests/test_lmstudio.py
@@ -1,0 +1,69 @@
+import requests
+
+from movie_agent.lmstudio import (
+    list_lmstudio_models,
+    generate_story_prompt_lmstudio,
+)
+
+
+def test_list_lmstudio_models(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"data": [{"id": "phi"}, {"id": "llama"}]}
+
+        def raise_for_status(self):
+            pass
+
+    def fake_get(url, timeout=None):
+        captured["url"] = url
+        return FakeResponse()
+
+    monkeypatch.setenv("LMSTUDIO_HOST", "http://example.com")
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    models = list_lmstudio_models()
+    assert captured["url"] == "http://example.com/v1/models"
+    assert models == ["phi", "llama"]
+
+
+def test_generate_story_prompt_lmstudio(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"choices": [{"message": {"content": "Once upon a time"}}]}
+
+        def raise_for_status(self):
+            pass
+
+    def fake_post(url, json=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        return FakeResponse()
+
+    monkeypatch.setenv("LMSTUDIO_HOST", "http://example.com")
+    monkeypatch.setattr(requests, "post", fake_post)
+
+    result = generate_story_prompt_lmstudio(
+        "context",
+        "modelA",
+        temperature=0.5,
+        max_tokens=10,
+        top_p=0.9,
+    )
+    assert captured["url"] == "http://example.com/v1/chat/completions"
+    assert captured["json"] == {
+        "model": "modelA",
+        "messages": [{"role": "user", "content": "context"}],
+        "temperature": 0.5,
+        "max_tokens": 10,
+        "top_p": 0.9,
+    }
+    assert result == "Once upon a time"
+


### PR DESCRIPTION
## Summary
- add `lmstudio.py` with helpers to list models and generate chat completions against LM Studio's API
- document `LMSTUDIO_HOST` environment variable for custom LM Studio endpoints
- add tests for LM Studio helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68997114c1408329b7a03db6731172d0