### PR TITLE
Support LMStudio backend for story prompts

### DIFF
--- a/tests/test_gui_llm_env.py
+++ b/tests/test_gui_llm_env.py
@@ -1,0 +1,30 @@
+import pandas as pd
+from movie_agent import gui
+
+
+def test_select_llm_models_lmstudio(monkeypatch):
+    df = pd.DataFrame({"llm_environment": ["LMStudio", "Ollama"]})
+    monkeypatch.setattr(gui, "list_lmstudio_models", lambda: ["lm"])
+    models = gui.select_llm_models(df)
+    assert models == ["lm"]
+
+
+def test_select_llm_models_ollama(monkeypatch):
+    df = pd.DataFrame({"llm_environment": ["Ollama"]})
+    monkeypatch.setattr(gui, "list_ollama_models", lambda: ["ol"])
+    models = gui.select_llm_models(df)
+    assert models == ["ol"]
+
+
+def test_generate_prompt_for_row_lmstudio(monkeypatch):
+    row = pd.Series({"llm_environment": "LMStudio"})
+    monkeypatch.setattr(gui, "generate_story_prompt_lmstudio", lambda *args, **kwargs: "lm_resp")
+    result = gui.generate_prompt_for_row(row, "ctx", "model", 0.5, 10, 0.9, 30)
+    assert result == "lm_resp"
+
+
+def test_generate_prompt_for_row_ollama(monkeypatch):
+    row = pd.Series({"llm_environment": "Ollama"})
+    monkeypatch.setattr(gui, "generate_story_prompt", lambda *args, **kwargs: "ol_resp")
+    result = gui.generate_prompt_for_row(row, "ctx", "model", 0.5, 10, 0.9, 30)
+    assert result == "ol_resp"


### PR DESCRIPTION
## Summary
- Select LMStudio models when `llm_environment` indicates LMStudio
- Route story prompt generation to LMStudio or Ollama based on each row
- Cover backend selection with new tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689972886d1c83298eabf284dcb95e29