### PR TITLE
test: add image csv column order check

### DIFF
--- a/tests/test_image_csv_columns.py
+++ b/tests/test_image_csv_columns.py
@@ -1,0 +1,43 @@
+# TODO: Remove this test after refactoring is complete.
+# 現在のカラム順を固定するための一時的なテストです。
+
+from movie_agent import csv_manager
+
+
+def test_image_csv_columns():
+    df = csv_manager.load_image_data("images.csv")
+    expected = [
+        "selected",
+        "id",
+        "category",
+        "tags",
+        "nsfw",
+        "ja_prompt",
+        "llm_model",
+        "llm_environment",
+        "image_prompt",
+        "negative_prompt",
+        "sfw_negative_prompt",
+        "image_path",
+        "post_url",
+        "post_site",
+        "post_id",
+        "wordpress_site",
+        "wordpress_account",
+        "views_yesterday",
+        "views_week",
+        "views_month",
+        "checkpoint",
+        "comfy_vae",
+        "comfy_lora",
+        "temperature",
+        "max_tokens",
+        "top_p",
+        "cfg",
+        "steps",
+        "seed",
+        "batch_count",
+        "width",
+        "height",
+    ]
+    assert list(df.columns) == expected


### PR DESCRIPTION
## Summary
- add temporary test ensuring `load_image_data` column order remains unchanged

## Testing
- `pytest tests/test_image_csv_columns.py`


------
https://chatgpt.com/codex/tasks/task_e_689bf7f926c48329b4b98c9a2d3e3e91