### PR TITLE
Add sample image CSV data and test for CSV manager

### DIFF
--- a/images.csv
+++ b/images.csv
@@ -1,1 +1,3 @@
 id,category,tags,nsfw,ja_prompt,llm_model,llm_environment,image_prompt,negative_prompt,sfw_negative_prompt,image_path,post_url,post_site,post_id,wordpress_site,wordpress_account,views_yesterday,views_week,views_month,checkpoint,comfy_vae,comfy_lora,temperature,max_tokens,top_p,cfg,steps,seed,batch_count,width,height
+"0001",cat1,tag1,False,サンプル1,gpt-oss:20b,Ollama,Sample prompt 1,,,,,,,,,0,0,0,,,,0.8,4096,0.95,7,28,1234,1,1024,1024
+"0002",cat2,tag2,True,サンプル2,phi3:mini,Ollama,Sample prompt 2,bad,,,,,,,,1,2,3,checkpoint2,,,0.7,2048,0.9,6,30,4321,2,768,768

--- a/tests/test_csv_manager.py
+++ b/tests/test_csv_manager.py
@@ -96,3 +96,22 @@ def test_load_image_data_adds_post_columns(tmp_path):
     assert df["sfw_negative_prompt"].eq("").all()
     assert "llm_environment" in df.columns
     assert df["llm_environment"].eq("Ollama").all()
+
+
+def test_load_image_data_sample():
+    df = load_image_data("images.csv")
+    assert len(df) == 2
+
+    row1 = df.iloc[0]
+    assert row1["id"] == "1"
+    assert row1["category"] == "cat1"
+    assert row1["tags"] == "tag1"
+    assert bool(row1["nsfw"]) is False
+    assert row1["ja_prompt"] == "サンプル1"
+    assert row1["llm_model"] == "gpt-oss:20b"
+    assert row1["image_prompt"] == "Sample prompt 1"
+
+    row2 = df.iloc[1]
+    assert row2["id"] == "2"
+    assert bool(row2["nsfw"]) is True
+    assert row2["views_week"] == 2


### PR DESCRIPTION
## Summary
- add two sample image entries to `images.csv`
- verify `load_image_data` reads the sample entries

## Testing
- `pytest tests/test_csv_manager.py::test_load_image_data_sample -q`


------
https://chatgpt.com/codex/tasks/task_e_689bfa562ff48329aab9e4fb52e1ba8e