### PR TITLE
refactor: centralize utility helpers

### DIFF
--- a/movie_agent/comfyui.py
+++ b/movie_agent/comfyui.py
@@ -7,6 +7,7 @@ from typing import List
 
 import requests
 import streamlit as st
+from movie_agent.utils import coerce_int, coerce_float
 
 # ComfyUI API host/port configuration
 COMFYUI_HOST = os.getenv("COMFYUI_HOST", "127.0.0.1")
@@ -21,38 +22,6 @@ DEFAULT_NEGATIVE_PROMPT = (
     "blurry, watermark, lowres, jpeg artifacts, nsfw, nipples, "
     "pubic hair, nude, exposed chest"
 )
-
-# Utility coercion helpers
-
-
-def _coerce_int(value, default, name, min_value=None):
-    """Convert ``value`` to int or return ``default`` and toast on error."""
-    if value in (None, ""):
-        return default
-    try:
-        value = int(value)
-    except (ValueError, TypeError):
-        st.toast(f"Invalid {name}; using default {default}")
-        return default
-    if min_value is not None and value < min_value:
-        st.toast(f"{name.capitalize()} must be >= {min_value}; using {default}")
-        return default
-    return value
-
-
-def _coerce_float(value, default, name, min_value=None):
-    """Convert ``value`` to float or return ``default`` and toast on error."""
-    if value in (None, ""):
-        return default
-    try:
-        value = float(value)
-    except (ValueError, TypeError):
-        st.toast(f"Invalid {name}; using default {default}")
-        return default
-    if min_value is not None and value < min_value:
-        st.toast(f"{name.capitalize()} must be >= {min_value}; using {default}")
-        return default
-    return value
 
 # Base workflow used for the ComfyUI /prompt API
 BASE_WORKFLOW = {
@@ -155,11 +124,11 @@ def generate_image(
     Returns a list of file paths for the saved images. If generation fails,
     an empty list is returned.
     """
-    seed = _coerce_int(seed, 0, "seed", min_value=0)
-    width = _coerce_int(width, DEFAULT_WIDTH, "width", min_value=1)
-    height = _coerce_int(height, DEFAULT_HEIGHT, "height", min_value=1)
-    cfg = _coerce_float(cfg, DEFAULT_CFG, "cfg", min_value=0)
-    steps = _coerce_int(steps, DEFAULT_STEPS, "steps", min_value=1)
+    seed = coerce_int(seed, 0, "seed", min_value=0)
+    width = coerce_int(width, DEFAULT_WIDTH, "width", min_value=1)
+    height = coerce_int(height, DEFAULT_HEIGHT, "height", min_value=1)
+    cfg = coerce_float(cfg, DEFAULT_CFG, "cfg", min_value=0)
+    steps = coerce_int(steps, DEFAULT_STEPS, "steps", min_value=1)
 
     base = f"http://{COMFYUI_HOST}:{COMFYUI_PORT}"
     prompt_url = f"{base}/prompt"

--- a/movie_agent/gui.py
+++ b/movie_agent/gui.py
@@ -6,6 +6,7 @@ import os
 import random
 from pathlib import Path
 from streamlit.components.v1 import html as component_html
+from movie_agent.utils import rerun_with_message
 from .comfyui import (
     list_comfy_models,
     generate_image,
@@ -69,12 +70,6 @@ def log_to_console(data: dict) -> None:
         f"<script>console.log('FramePack request:', {json.dumps(data)});</script>",
         height=0,
     )
-
-
-def rerun_with_message(message: str) -> None:
-    """Trigger st.rerun() and show a message after reload."""
-    st.session_state["just_rerun"] = message
-    st.rerun()
 
 
 def select_llm_models(df: pd.DataFrame) -> list[str]:

--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -11,6 +11,7 @@ from typing import Optional, Dict, Any
 import requests
 import streamlit as st
 import pandas as pd
+from movie_agent.utils import coerce_int, coerce_float, rerun_with_message
 from movie_agent.comfyui import (
     list_comfy_models,
     generate_image,
@@ -53,46 +54,6 @@ DEFAULT_TIMEOUT = 300
 DEFAULT_BATCH = 1
 
 st.set_page_config(page_title="Image Agent", layout="wide")
-
-
-def coerce_int(value, default, label, row_id, min_value=None):
-    """Safely convert ``value`` to int or return ``default`` with a toast."""
-    if pd.isna(value) or str(value).strip() == "":
-        return default
-    try:
-        value = int(value)
-    except (ValueError, TypeError):
-        st.toast(f"Invalid {label} for row {row_id}; using default {default}")
-        return default
-    if min_value is not None and value < min_value:
-        st.toast(
-            f"{label.capitalize()} must be >= {min_value} for row {row_id}; using {default}"
-        )
-        return default
-    return value
-
-
-def coerce_float(value, default, label, row_id, min_value=None):
-    """Safely convert ``value`` to float or return ``default`` with a toast."""
-    if pd.isna(value) or str(value).strip() == "":
-        return default
-    try:
-        value = float(value)
-    except (ValueError, TypeError):
-        st.toast(f"Invalid {label} for row {row_id}; using default {default}")
-        return default
-    if min_value is not None and value < min_value:
-        st.toast(
-            f"{label.capitalize()} must be >= {min_value} for row {row_id}; using {default}"
-        )
-        return default
-    return value
-
-
-def rerun_with_message(message: str) -> None:
-    """Trigger st.rerun() and show a message after reload."""
-    st.session_state["just_rerun"] = message
-    st.rerun()
 
 
 def build_image_prompt_context(row: pd.Series) -> str:

--- a/movie_agent/utils.py
+++ b/movie_agent/utils.py
@@ -1,0 +1,54 @@
+import pandas as pd
+import streamlit as st
+
+
+def coerce_int(value, default, label, row_id=None, min_value=None):
+    """Safely convert ``value`` to int or return ``default`` with a toast."""
+    if pd.isna(value) or str(value).strip() == "":
+        return default
+    try:
+        value = int(value)
+    except (ValueError, TypeError):
+        if row_id is not None:
+            st.toast(f"Invalid {label} for row {row_id}; using default {default}")
+        else:
+            st.toast(f"Invalid {label}; using default {default}")
+        return default
+    if min_value is not None and value < min_value:
+        if row_id is not None:
+            st.toast(
+                f"{label.capitalize()} must be >= {min_value} for row {row_id}; using {default}"
+            )
+        else:
+            st.toast(f"{label.capitalize()} must be >= {min_value}; using {default}")
+        return default
+    return value
+
+
+def coerce_float(value, default, label, row_id=None, min_value=None):
+    """Safely convert ``value`` to float or return ``default`` with a toast."""
+    if pd.isna(value) or str(value).strip() == "":
+        return default
+    try:
+        value = float(value)
+    except (ValueError, TypeError):
+        if row_id is not None:
+            st.toast(f"Invalid {label} for row {row_id}; using default {default}")
+        else:
+            st.toast(f"Invalid {label}; using default {default}")
+        return default
+    if min_value is not None and value < min_value:
+        if row_id is not None:
+            st.toast(
+                f"{label.capitalize()} must be >= {min_value} for row {row_id}; using {default}"
+            )
+        else:
+            st.toast(f"{label.capitalize()} must be >= {min_value}; using {default}")
+        return default
+    return value
+
+
+def rerun_with_message(message: str) -> None:
+    """Trigger st.rerun() and show a message after reload."""
+    st.session_state["just_rerun"] = message
+    st.rerun()


### PR DESCRIPTION
## Summary
- move `coerce_int`, `coerce_float` and `rerun_with_message` into new `movie_agent/utils.py`
- update GUI and image modules to reuse the shared helpers
- streamline ComfyUI numeric validation with shared utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c059bc7ac83298aaec0c25369931f