### PR TITLE
refactor: centralize llm helpers

### DIFF
--- a/movie_agent/gui.py
+++ b/movie_agent/gui.py
@@ -14,8 +14,8 @@ from .comfyui import (
     DEFAULT_STEPS,
 )
 from . import framepack
-from .ollama import list_ollama_models, generate_story_prompt, DEBUG_MODE
-from .lmstudio import list_lmstudio_models, generate_story_prompt_lmstudio
+from .ollama import DEBUG_MODE
+from .llm_helpers import select_llm_models, generate_prompt_for_row
 from .csv_manager import (
     load_data,
     save_data,
@@ -69,47 +69,6 @@ def log_to_console(data: dict) -> None:
     component_html(
         f"<script>console.log('FramePack request:', {json.dumps(data)});</script>",
         height=0,
-    )
-
-
-def select_llm_models(df: pd.DataFrame) -> list[str]:
-    """Return available LLM models based on the ``llm_environment`` column."""
-    if (
-        "llm_environment" in df.columns
-        and df["llm_environment"].astype(str).str.lower().eq("lmstudio").any()
-    ):
-        return list_lmstudio_models()
-    return list_ollama_models()
-
-
-def generate_prompt_for_row(
-    row: pd.Series,
-    synopsis: str,
-    model: str,
-    temperature: float,
-    max_tokens: int,
-    top_p: float,
-    timeout: int,
-) -> str | None:
-    """Generate a story prompt using the appropriate backend."""
-    env = str(row.get("llm_environment", "")).strip().lower()
-    if env == "lmstudio":
-        return generate_story_prompt_lmstudio(
-            synopsis,
-            model,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            top_p=top_p,
-            timeout=timeout,
-        )
-    return generate_story_prompt(
-        synopsis,
-        model,
-        temperature,
-        max_tokens,
-        top_p,
-        debug=DEBUG_MODE,
-        timeout=timeout,
     )
 
 

--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -19,12 +19,8 @@ from movie_agent.comfyui import (
     DEFAULT_STEPS,
     DEFAULT_NEGATIVE_PROMPT,
 )
-from movie_agent.ollama import (
-    list_ollama_models,
-    generate_story_prompt,
-    DEBUG_MODE,
-)
-from movie_agent.lmstudio import generate_story_prompt_lmstudio, list_lmstudio_models
+from movie_agent.ollama import DEBUG_MODE
+from movie_agent.llm_helpers import select_llm_models, generate_prompt_for_row
 from movie_agent.csv_manager import (
     load_image_data,
     save_data,
@@ -175,47 +171,6 @@ def fetch_view_counts(site: str, post_id: str) -> Dict[str, int]:
         views = data.get("views", [])
         results[column] = views[0] if views else 0
     return results
-
-
-def select_llm_models(df: pd.DataFrame) -> list[str]:
-    """Return available LLM models based on ``llm_environment`` column."""
-    if (
-        "llm_environment" in df.columns
-        and df["llm_environment"].astype(str).str.lower().eq("lmstudio").any()
-    ):
-        return list_lmstudio_models()
-    return list_ollama_models()
-
-
-def generate_prompt_for_row(
-    row: pd.Series,
-    context: str,
-    model: str,
-    temperature: float,
-    max_tokens: Optional[int],
-    top_p: Optional[float],
-    timeout: int,
-) -> Optional[str]:
-    """Generate a prompt using the appropriate LLM backend."""
-    env = str(row.get("llm_environment", "")).strip().lower()
-    if env == "lmstudio":
-        return generate_story_prompt_lmstudio(
-            context,
-            model,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            top_p=top_p,
-            timeout=timeout,
-        )
-    return generate_story_prompt(
-        context,
-        model=model,
-        temperature=temperature,
-        max_tokens=max_tokens,
-        top_p=top_p,
-        debug=DEBUG_MODE,
-        timeout=timeout,
-    )
 
 
 def main() -> None:

--- a/movie_agent/llm_helpers.py
+++ b/movie_agent/llm_helpers.py
@@ -1,0 +1,49 @@
+import pandas as pd
+from typing import Optional
+
+from .ollama import list_ollama_models, generate_story_prompt, DEBUG_MODE
+from .lmstudio import list_lmstudio_models, generate_story_prompt_lmstudio
+
+
+def select_llm_models(df: pd.DataFrame) -> list[str]:
+    """Return available LLM models based on the ``llm_environment`` column."""
+    if (
+        "llm_environment" in df.columns
+        and df["llm_environment"].astype(str).str.lower().eq("lmstudio").any()
+    ):
+        return list_lmstudio_models()
+    return list_ollama_models()
+
+
+def generate_prompt_for_row(
+    row: pd.Series,
+    context: str,
+    model: str,
+    temperature: float,
+    max_tokens: Optional[int],
+    top_p: Optional[float],
+    timeout: int,
+) -> Optional[str]:
+    """Generate a prompt using the appropriate LLM backend."""
+    env = str(row.get("llm_environment", "")).strip().lower()
+    if env == "lmstudio":
+        return generate_story_prompt_lmstudio(
+            context,
+            model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            timeout=timeout,
+        )
+    return generate_story_prompt(
+        context,
+        model=model,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        top_p=top_p,
+        debug=DEBUG_MODE,
+        timeout=timeout,
+    )
+
+
+__all__ = ["select_llm_models", "generate_prompt_for_row"]

--- a/tests/test_gui_llm_env.py
+++ b/tests/test_gui_llm_env.py
@@ -1,30 +1,34 @@
 import pandas as pd
-from movie_agent import gui
+from movie_agent import llm_helpers
 
 
 def test_select_llm_models_lmstudio(monkeypatch):
     df = pd.DataFrame({"llm_environment": ["LMStudio", "Ollama"]})
-    monkeypatch.setattr(gui, "list_lmstudio_models", lambda: ["lm"])
-    models = gui.select_llm_models(df)
+    monkeypatch.setattr(llm_helpers, "list_lmstudio_models", lambda: ["lm"])
+    models = llm_helpers.select_llm_models(df)
     assert models == ["lm"]
 
 
 def test_select_llm_models_ollama(monkeypatch):
     df = pd.DataFrame({"llm_environment": ["Ollama"]})
-    monkeypatch.setattr(gui, "list_ollama_models", lambda: ["ol"])
-    models = gui.select_llm_models(df)
+    monkeypatch.setattr(llm_helpers, "list_ollama_models", lambda: ["ol"])
+    models = llm_helpers.select_llm_models(df)
     assert models == ["ol"]
 
 
 def test_generate_prompt_for_row_lmstudio(monkeypatch):
     row = pd.Series({"llm_environment": "LMStudio"})
-    monkeypatch.setattr(gui, "generate_story_prompt_lmstudio", lambda *args, **kwargs: "lm_resp")
-    result = gui.generate_prompt_for_row(row, "ctx", "model", 0.5, 10, 0.9, 30)
+    monkeypatch.setattr(
+        llm_helpers, "generate_story_prompt_lmstudio", lambda *args, **kwargs: "lm_resp"
+    )
+    result = llm_helpers.generate_prompt_for_row(row, "ctx", "model", 0.5, 10, 0.9, 30)
     assert result == "lm_resp"
 
 
 def test_generate_prompt_for_row_ollama(monkeypatch):
     row = pd.Series({"llm_environment": "Ollama"})
-    monkeypatch.setattr(gui, "generate_story_prompt", lambda *args, **kwargs: "ol_resp")
-    result = gui.generate_prompt_for_row(row, "ctx", "model", 0.5, 10, 0.9, 30)
+    monkeypatch.setattr(
+        llm_helpers, "generate_story_prompt", lambda *args, **kwargs: "ol_resp"
+    )
+    result = llm_helpers.generate_prompt_for_row(row, "ctx", "model", 0.5, 10, 0.9, 30)
     assert result == "ol_resp"

--- a/tests/test_llm_environment.py
+++ b/tests/test_llm_environment.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from movie_agent.csv_manager import load_image_data
-from movie_agent import image_ui
+from movie_agent import llm_helpers
 
 
 def test_load_image_data_sets_llm_environment(tmp_path):
@@ -23,10 +23,10 @@ def test_generate_prompt_for_row_lmstudio(monkeypatch):
         calls["ollama"] = True
         return "ol"
 
-    monkeypatch.setattr(image_ui, "generate_story_prompt_lmstudio", fake_lmstudio)
-    monkeypatch.setattr(image_ui, "generate_story_prompt", fake_ollama)
+    monkeypatch.setattr(llm_helpers, "generate_story_prompt_lmstudio", fake_lmstudio)
+    monkeypatch.setattr(llm_helpers, "generate_story_prompt", fake_ollama)
 
-    result = image_ui.generate_prompt_for_row(row, "ctx", "model", 0.5, 10, 0.9, 30)
+    result = llm_helpers.generate_prompt_for_row(row, "ctx", "model", 0.5, 10, 0.9, 30)
     assert result == "lm"
     assert calls.get("lmstudio")
     assert "ollama" not in calls
@@ -44,10 +44,10 @@ def test_generate_prompt_for_row_ollama(monkeypatch):
         calls["ollama"] = True
         return "ol"
 
-    monkeypatch.setattr(image_ui, "generate_story_prompt_lmstudio", fake_lmstudio)
-    monkeypatch.setattr(image_ui, "generate_story_prompt", fake_ollama)
+    monkeypatch.setattr(llm_helpers, "generate_story_prompt_lmstudio", fake_lmstudio)
+    monkeypatch.setattr(llm_helpers, "generate_story_prompt", fake_ollama)
 
-    result = image_ui.generate_prompt_for_row(row, "ctx", "model", 0.5, 10, 0.9, 30)
+    result = llm_helpers.generate_prompt_for_row(row, "ctx", "model", 0.5, 10, 0.9, 30)
     assert result == "ol"
     assert calls.get("ollama")
     assert "lmstudio" not in calls


### PR DESCRIPTION
## Summary
- move LLM helper functions into new `llm_helpers` module
- update GUI modules to import shared helpers
- adjust tests for new module

## Testing
- `pytest tests/test_gui_llm_env.py tests/test_llm_environment.py`

------
https://chatgpt.com/codex/tasks/task_e_689c0827f5fc8329a9682d295bb26631