### PR TITLE
Introduce project-wide logger and replace prints in UIs

### DIFF
--- a/movie_agent/logger.py
+++ b/movie_agent/logger.py
@@ -1,0 +1,9 @@
+import logging
+
+logger = logging.getLogger("movie_agent")
+if not logger.handlers:
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)


### PR DESCRIPTION
## Summary
- add shared `movie_agent.logger` with stream handler
- refactor `image_ui.py` and `gui.py` to use logger instead of print
- log stack traces via `logger.exception` alongside `st.error`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c0f2ab4508329a9db077633b06b3d