### PR TITLE
Fix blank row handling in image CSV

### DIFF
--- a/movie_agent/csv_manager.py
+++ b/movie_agent/csv_manager.py
@@ -88,6 +88,7 @@ def load_image_data(path: str) -> pd.DataFrame:
         for col, default in IMAGE_DEFAULTS.items():
             df[col] = default
     else:
+        df = df.dropna(how="all")
         missing_cols = [c for c in columns if c not in df.columns]
         for c in missing_cols:
             df[c] = IMAGE_DEFAULTS.get(c, "")

--- a/tests/test_csv_manager.py
+++ b/tests/test_csv_manager.py
@@ -124,3 +124,22 @@ def test_load_image_data_sanitizes_strings(tmp_path):
     assert df.loc[0, "checkpoint"] == ""
     assert df.loc[0, "comfy_vae"] == ""
     assert df.loc[0, "comfy_lora"] == ""
+
+
+def test_load_image_data_ignores_blank_rows(tmp_path):
+    path = tmp_path / "img.csv"
+    pd.DataFrame(
+        {
+            "id": ["1"],
+            "category": ["cat"],
+            "tags": ["tag"],
+            "nsfw": [False],
+            "ja_prompt": ["prompt"],
+        }
+    ).to_csv(path, index=False)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write("\n")
+
+    df = load_image_data(path)
+    assert len(df) == 1
+    assert df.iloc[0]["id"] == "1"


### PR DESCRIPTION
## Summary
- ignore empty rows when loading images.csv
- add regression test covering blank row scenario

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bf766d71083298489d1a7c9f784cb