### PR TITLE
Load tag metadata in GUI and display as caption

### DIFF
--- a/movie_agent/gui.py
+++ b/movie_agent/gui.py
@@ -77,12 +77,20 @@ def log_to_console(data: dict) -> None:
 
 def main() -> None:
     """Run the Streamlit GUI."""
+    tag_path = Path(__file__).resolve().parent / "tag.json"
+    tags: list[str] = []
+    if tag_path.exists():
+        with tag_path.open(encoding="utf-8") as f:
+            data = json.load(f)
+            tags = data.get("tags", []) if isinstance(data, dict) else data
+
     # Display notice if the page was refreshed by st.rerun()
     msg = st.session_state.pop("just_rerun", None)
     if msg:
         st.info(msg)
 
     st.title("Streamlit Video Agent")
+    st.caption(", ".join(tags))
 
     if "video_df" not in st.session_state:
         st.session_state.video_df = load_data(CSV_FILE)


### PR DESCRIPTION
## Summary
- Load `tag.json` at GUI startup and extract tags
- Show tag list beneath the title using `st.caption`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d7d841a88832982b9c06ff651fe9d