### PR TITLE
Display tags from tag.json in Streamlit GUI

### DIFF
--- a/movie_agent/gui.py
+++ b/movie_agent/gui.py
@@ -44,6 +44,13 @@ if args.debug:
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 CSV_FILE = str(BASE_DIR / "videos.csv")
+TAG_FILE = BASE_DIR / "tag.json"
+
+try:
+    with TAG_FILE.open("r", encoding="utf-8") as f:
+        tags = json.load(f).get("tags", [])
+except (FileNotFoundError, json.JSONDecodeError):
+    tags = []
 
 # Default generation parameters
 DEFAULT_MODEL = "phi3:mini"
@@ -83,6 +90,7 @@ def main() -> None:
         st.info(msg)
 
     st.title("Streamlit Video Agent")
+    st.caption(", ".join(tags))
 
     if "video_df" not in st.session_state:
         st.session_state.video_df = load_data(CSV_FILE)

--- a/tag.json
+++ b/tag.json
@@ -1,0 +1,3 @@
+{
+  "tags": ["sample-tag"]
+}


### PR DESCRIPTION
## Summary
- load tags from new tag.json and gracefully handle missing file
- show tag list beneath the Streamlit title

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689d84eb5d70832989fbc3dcb7ed6b72