### PR TITLE
Add tag translation workflow using LMStudio

### DIFF
--- a/movie_agent/lmstudio.py
+++ b/movie_agent/lmstudio.py
@@ -11,6 +11,8 @@ import os
 import requests
 import streamlit as st
 
+from movie_agent.logger import logger
+
 
 def _base_url() -> str:
     """Return the base URL for LM Studio from the environment."""
@@ -63,5 +65,45 @@ def generate_story_prompt_lmstudio(
         return None
 
 
-__all__ = ["list_lmstudio_models", "generate_story_prompt_lmstudio"]
+def translate_with_lmstudio(
+    text: str,
+    lang: str,
+    model: str = "",
+    timeout: int = 300,
+    log_prompt: bool = False,
+) -> str | None:
+    """Translate ``text`` into ``lang`` using LM Studio's chat API.
+
+    If ``model`` is an empty string, the server's default model is used.
+    Set ``log_prompt`` to ``True`` to log the generated prompt for debugging.
+    """
+
+    url = f"{_base_url()}/v1/chat/completions"
+    prompt = (
+        "翻訳ツールのように回答してくれ。余計な説明などはなく訳だけを答えてくれ。"
+        f"この言葉「{text}」を言語「{lang}に記載されている文字列」に翻訳してくれ"
+    )
+    if log_prompt:
+        logger.info(prompt)
+    payload: dict[str, object] = {
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0,
+    }
+    if model:
+        payload["model"] = model
+    try:
+        res = requests.post(url, json=payload, timeout=timeout)
+        res.raise_for_status()
+        data = res.json()
+        return data["choices"][0]["message"]["content"]
+    except (requests.exceptions.RequestException, KeyError, IndexError, ValueError) as e:
+        st.error(f"LM Studio API error: {e}")
+        return None
+
+
+__all__ = [
+    "list_lmstudio_models",
+    "generate_story_prompt_lmstudio",
+    "translate_with_lmstudio",
+]
 


### PR DESCRIPTION
## Summary
- add LM Studio helper for tag translation
- extend image UI with "Generate tag" button that translates tags per row
- cover new helper with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d8a3f18a08329af56494d997e0ee6