### PR TITLE
Refine tag translation and ignore tag config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Repository unipue
 
 videos.csv
+tag.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -309,10 +309,9 @@ def main() -> None:
             error = False
             for i, (idx, row) in enumerate(selected_rows):
                 tag = tag_list[i % len(tag_list)]
-                lang = str(row.get("id") or "").strip()
                 result = translate_with_lmstudio(
                     tag,
-                    lang,
+                    str(row.get("id") or "").strip(),
                     log_prompt=(i == 0),
                 )
                 if result is None:

--- a/movie_agent/lmstudio.py
+++ b/movie_agent/lmstudio.py
@@ -79,10 +79,8 @@ def translate_with_lmstudio(
     """
 
     url = f"{_base_url()}/v1/chat/completions"
-    prompt = (
-        "翻訳ツールのように回答してくれ。余計な説明などはなく訳だけを答えてくれ。"
-        f"この言葉「{text}」を言語「{lang}に記載されている文字列」に翻訳してくれ"
-    )
+    prompt = f"翻訳ツールのように回答してくれ。余計な説明などはなく訳だけを答えてくれ。この言葉「{text}」を言語「{lang}」に翻訳してくれ"
+
     if log_prompt:
         logger.info(prompt)
     payload: dict[str, object] = {


### PR DESCRIPTION
## Summary
- streamline tag translation prompt to omit extraneous wording
- inline row id when translating tags
- ignore tag.json in version control

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d8fbc131883298aa80d752aa6c435