### PR TITLE
Add alt text support when posting images to WordPress

### DIFF
--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -120,11 +120,12 @@ def post_to_wordpress(row: pd.Series) -> Optional[Dict[str, Any]]:
         return None
 
     media = []
+    alt_text = row.get("alt_text", "")
     for p in sorted(image_dir.glob("*")):
         if p.is_file():
             with open(p, "rb") as f:
                 encoded = base64.b64encode(f.read()).decode("utf-8")
-            media.append({"filename": p.name, "data": encoded})
+            media.append({"filename": p.name, "data": encoded, "alt": alt_text})
 
     account = row.get("wordpress_account")
     if account is None or str(account).strip() == "":
@@ -256,6 +257,7 @@ def main() -> None:
                 "LLM Environment", options=["Ollama", "LMStudio"]
             ),
             "image_prompt": st.column_config.TextColumn("Image Prompt"),
+            "alt_text": st.column_config.TextColumn("Alt Text"),
             "negative_prompt": st.column_config.TextColumn("Negative Prompt"),
             "sfw_negative_prompt": st.column_config.TextColumn("SFW Negative Prompt"),
             "image_path": st.column_config.LinkColumn("Image Path"),

--- a/tests/test_wordpress_post.py
+++ b/tests/test_wordpress_post.py
@@ -41,6 +41,7 @@ def test_post_to_wordpress(monkeypatch, tmp_path):
             "image_path": str(tmp_path),
             "wordpress_site": "mysite",
             "wordpress_account": "myacct",
+            "alt_text": "my alt",
         }
     )
     result = post_to_wordpress(row)
@@ -62,6 +63,8 @@ def test_post_to_wordpress(monkeypatch, tmp_path):
     assert payload["content"] == "cute, funny"
     # Media should list images in sorted order
     assert [m["filename"] for m in payload["media"]] == ["a.png", "b.png"]
+    # Alt text should be forwarded for each media item
+    assert all(m["alt"] == "my alt" for m in payload["media"])
     # Site should be forwarded in payload
     assert payload["site"] == "mysite"
     assert payload["account"] == "myacct"
@@ -101,6 +104,7 @@ def test_post_to_wordpress_payload_has_site(monkeypatch, tmp_path):
             "image_path": str(tmp_path),
             "wordpress_site": "mysite",
             "wordpress_account": "myacct",
+            "alt_text": "my alt",
         }
     )
 
@@ -141,6 +145,7 @@ def test_post_to_wordpress_records_site_and_id(monkeypatch, tmp_path):
                 "image_path": str(tmp_path),
                 "wordpress_site": "mysite",
                 "wordpress_account": "myacct",
+                "alt_text": "my alt",
             }
         ]
     )
@@ -180,6 +185,7 @@ def test_post_to_wordpress_http_error(monkeypatch, tmp_path):
             "image_path": str(tmp_path),
             "wordpress_site": "mysite",
             "wordpress_account": "myacct",
+            "alt_text": "my alt",
         }
     )
     assert post_to_wordpress(row) is None
@@ -214,6 +220,7 @@ def test_post_to_wordpress_bad_status(monkeypatch, tmp_path):
             "image_path": str(tmp_path),
             "wordpress_site": "mysite",
             "wordpress_account": "myacct",
+            "alt_text": "my alt",
         }
     )
     assert post_to_wordpress(row) is None
@@ -248,6 +255,7 @@ def test_post_to_wordpress_no_url(monkeypatch, tmp_path):
             "image_path": str(tmp_path),
             "wordpress_site": "mysite",
             "wordpress_account": "myacct",
+            "alt_text": "my alt",
         }
     )
     assert post_to_wordpress(row) is None
@@ -271,6 +279,7 @@ def test_post_to_wordpress_missing_site(monkeypatch, tmp_path):
         "tags": "cute",
         "image_path": str(tmp_path),
         "wordpress_account": "myacct",
+        "alt_text": "my alt",
     })
     assert post_to_wordpress(row) is None
     assert errors and "WordPressサイトが指定されていません" in errors[0]
@@ -294,6 +303,7 @@ def test_post_to_wordpress_missing_account(monkeypatch, tmp_path):
             "tags": "cute",
             "image_path": str(tmp_path),
             "wordpress_site": "mysite",
+            "alt_text": "my alt",
         }
     )
     assert post_to_wordpress(row) is None
@@ -319,6 +329,7 @@ def test_post_to_wordpress_empty_account(monkeypatch, tmp_path):
             "image_path": str(tmp_path),
             "wordpress_site": "mysite",
             "wordpress_account": "",
+            "alt_text": "my alt",
         }
     )
     assert post_to_wordpress(row) is None


### PR DESCRIPTION
## Summary
- include `alt_text` for each media item when posting to WordPress
- expose `alt_text` in Streamlit image editor
- test WordPress posting with alt text

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689daf1c078c8329ac5cde5bcadbd058