### PR TITLE
Batch JSON-LD generation with caching

### DIFF
--- a/movie_agent/row_utils.py
+++ b/movie_agent/row_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Any, List
 
 import pandas as pd
 
@@ -19,3 +19,37 @@ def iterate_selected(df: pd.DataFrame, callback: Callable[[int, pd.Series], None
     mask = df["selected"].fillna(False).astype(bool)
     for idx, row in df[mask].iterrows():
         callback(idx, row)
+
+
+def batch_request_selected(
+    df: pd.DataFrame,
+    prompt_builder: Callable[[pd.Series], str],
+    request_fn: Callable[[List[str]], List[Any]],
+    cache: dict[str, Any],
+) -> None:
+    """Fetch LLM responses for selected rows in a single batch.
+
+    ``prompt_builder`` constructs the prompt string for each row.  ``request_fn``
+    receives a list of prompts and must return a list of results in the same
+    order.  Any prompts already present in ``cache`` are skipped.  Newly fetched
+    results are stored in ``cache`` keyed by the prompt string.
+    """
+    if "selected" not in df.columns:
+        return
+
+    mask = df["selected"].fillna(False).astype(bool)
+    prompts: List[str] = []
+    for _, row in df[mask].iterrows():
+        prompt = prompt_builder(row)
+        if prompt not in cache:
+            prompts.append(prompt)
+
+    if not prompts:
+        return
+
+    results = request_fn(prompts)
+    for prompt, result in zip(prompts, results):
+        cache[prompt] = result
+
+
+__all__ = ["iterate_selected", "batch_request_selected"]

--- a/tests/test_batch_request_selected.py
+++ b/tests/test_batch_request_selected.py
@@ -1,0 +1,27 @@
+import pandas as pd
+from movie_agent.row_utils import batch_request_selected
+
+def test_batch_request_selected(monkeypatch):
+    df = pd.DataFrame([
+        {"selected": True, "slug": "a"},
+        {"selected": True, "slug": "b"},
+    ])
+
+    def prompt_builder(row: pd.Series) -> str:  # type: ignore[name-defined]
+        return f"ctx-{row['slug']}"
+
+    call_count = {"count": 0}
+
+    def request_fn(prompts):
+        call_count["count"] += 1
+        assert prompts == ["ctx-a", "ctx-b"]
+        return ["r1", "r2"]
+
+    cache: dict[str, str] = {}
+    batch_request_selected(df, prompt_builder, request_fn, cache)
+    assert call_count["count"] == 1
+    assert cache["ctx-a"] == "r1"
+    assert cache["ctx-b"] == "r2"
+
+    batch_request_selected(df, prompt_builder, request_fn, cache)
+    assert call_count["count"] == 1


### PR DESCRIPTION
## Summary
- Add generic `batch_request_selected` helper to gather prompts and make one LLM call for multiple rows
- Cache JSON-LD/alt text responses and populate fields without repeated requests
- Cover batch helper with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dc1d7bce48329abee50b400be1f42