### PR TITLE
Handle non-string image metadata in CSV loader

### DIFF
--- a/movie_agent/csv_manager.py
+++ b/movie_agent/csv_manager.py
@@ -106,6 +106,12 @@ def load_image_data(path: str) -> pd.DataFrame:
         df["alt_text"] = df["alt_text"].fillna("").astype(str)
         df["slug"] = df["slug"].fillna("").astype(str)
         df["excerpt"] = df["excerpt"].fillna("").astype(str)
+        df["canonical_url"] = df["canonical_url"].where(
+            df["canonical_url"].apply(lambda x: isinstance(x, str)), ""
+        ).fillna("").astype(str)
+        df["meta_keywords"] = df["meta_keywords"].where(
+            df["meta_keywords"].apply(lambda x: isinstance(x, str)), ""
+        ).fillna("").astype(str)
         df["json_ld"] = df["json_ld"].fillna("").astype(str)
         df["negative_prompt"] = df["negative_prompt"].fillna("").astype(str)
         df["sfw_negative_prompt"] = df["sfw_negative_prompt"].fillna("").astype(str)

--- a/tests/test_csv_manager.py
+++ b/tests/test_csv_manager.py
@@ -136,3 +136,24 @@ def test_load_image_data_ignores_blank_rows(tmp_path):
     df = load_image_data(path)
     assert len(df) == 1
     assert df.iloc[0]["id"] == "1"
+
+
+def test_load_image_data_sanitizes_meta_fields(tmp_path):
+    path = tmp_path / "img.csv"
+    pd.DataFrame(
+        {
+            "id": ["1", "2"],
+            "canonical_url": [123, pd.NA],
+            "meta_keywords": [pd.NA, 456],
+        }
+    ).to_csv(path, index=False)
+
+    df = load_image_data(path)
+    assert df["canonical_url"].tolist() == ["", ""]
+    assert df["meta_keywords"].tolist() == ["", ""]
+
+    save_path = tmp_path / "out.csv"
+    save_data(df, save_path)
+    loaded = pd.read_csv(save_path, dtype=str).fillna("")
+    assert loaded["canonical_url"].tolist() == ["", ""]
+    assert loaded["meta_keywords"].tolist() == ["", ""]


### PR DESCRIPTION
## Summary
- Clean `canonical_url` and `meta_keywords` columns in `load_image_data` to ensure numeric or NaN values become empty strings
- Add regression test confirming metadata fields are sanitized and saved correctly

## Testing
- `pytest -q`
- `streamlit run movie_agent/image_ui.py --server.headless true`

------
https://chatgpt.com/codex/tasks/task_e_689dc541ff6c8329b6cf6c63e00f5a8e