### PR TITLE
Set zero default temperature for LLM interactions

### DIFF
--- a/movie_agent/csv_schema.py
+++ b/movie_agent/csv_schema.py
@@ -2,7 +2,7 @@ from .comfyui import DEFAULT_CFG, DEFAULT_STEPS
 
 # Default generation parameters used when initializing a new CSV
 DEFAULT_MODEL = "gpt-oss:20b"
-DEFAULT_TEMPERATURE = 0.8
+DEFAULT_TEMPERATURE = 0.0
 DEFAULT_MAX_TOKENS = 4096
 DEFAULT_TOP_P = 0.95
 DEFAULT_SEED = 31337

--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -30,7 +30,6 @@ from movie_agent.csv_manager import (
     DEFAULT_WIDTH,
     DEFAULT_HEIGHT,
     DEFAULT_SEED,
-    DEFAULT_TEMPERATURE,
 )
 from movie_agent.row_utils import iterate_selected, batch_request_selected
 from movie_agent.logger import logger
@@ -372,7 +371,7 @@ def main() -> None:
                         if not model:
                             model = DEFAULT_MODEL
                         kwargs = {}
-                        for key in ("temperature", "max_tokens", "top_p"):
+                        for key in ("max_tokens", "top_p"):
                             val = row.get(key)
                             if pd.notna(val) and val != "":
                                 kwargs[key] = val
@@ -381,7 +380,7 @@ def main() -> None:
                             row,
                             synopsis,
                             model,
-                            kwargs.get("temperature", DEFAULT_TEMPERATURE),
+                            0.8,
                             kwargs.get("max_tokens"),
                             kwargs.get("top_p"),
                             int(row.get("timeout", DEFAULT_TIMEOUT) or DEFAULT_TIMEOUT),
@@ -431,7 +430,7 @@ def main() -> None:
             first_row = df_to_generate.iloc[0]
             model = first_row.get("llm_model") or DEFAULT_MODEL
             kwargs: Dict[str, Any] = {}
-            for key in ("temperature", "max_tokens", "top_p"):
+            for key in ("max_tokens", "top_p"):
                 val = first_row.get(key)
                 if pd.notna(val) and val != "":
                     kwargs[key] = val
@@ -446,7 +445,7 @@ def main() -> None:
                 first_row,
                 combined,
                 model,
-                kwargs.get("temperature", DEFAULT_TEMPERATURE),
+                0.0,
                 kwargs.get("max_tokens"),
                 kwargs.get("top_p"),
                 timeout,

--- a/movie_agent/lmstudio.py
+++ b/movie_agent/lmstudio.py
@@ -37,12 +37,28 @@ def list_lmstudio_models(timeout: int | None = 30) -> list[str]:
 def generate_story_prompt_lmstudio(
     context: str,
     model: str,
-    temperature: float = 0.8,
+    temperature: float = 0.0,
     max_tokens: int | None = None,
     top_p: float | None = None,
     timeout: int = 300,
 ) -> str | None:
-    """Generate text using LM Studio's chat completions API."""
+    """Generate text using LM Studio's chat completions API.
+
+    Parameters
+    ----------
+    context : str
+        Combined context or instructions for the model.
+    model : str
+        LM Studio model name to use.
+    temperature : float, default 0.0
+        Sampling temperature for the generation.
+    max_tokens : int | None, optional
+        Maximum tokens to generate.
+    top_p : float | None, optional
+        Nucleus sampling parameter.
+    timeout : int, default 300
+        Request timeout in seconds.
+    """
 
     url = f"{_base_url()}/v1/chat/completions"
     payload: dict[str, object] = {

--- a/movie_agent/ollama.py
+++ b/movie_agent/ollama.py
@@ -49,7 +49,7 @@ def list_ollama_models(debug: bool | None = None) -> list[str]:
 def generate_story_prompt(
     context: str,
     model: str,
-    temperature: float = 0.8,
+    temperature: float = 0.0,
     max_tokens: int | None = None,
     top_p: float | None = None,
     debug: bool | None = None,
@@ -64,7 +64,7 @@ def generate_story_prompt(
         base prompt, NSFW flag).
     model : str
         Ollama model name to use.
-    temperature : float, default 0.8
+    temperature : float, default 0.0
         Sampling temperature passed to Ollama.
     max_tokens : int | None, optional
         Maximum tokens to generate.

--- a/tests/test_ollama.py
+++ b/tests/test_ollama.py
@@ -55,5 +55,5 @@ def test_generate_story_prompt(monkeypatch):
         "model": "phi3:mini",
         "prompt": context,
         "stream": False,
-        "options": {"temperature": 0.8},
+        "options": {"temperature": 0.0},
     }


### PR DESCRIPTION
## Summary
- default LLM temperature set to 0.0 across CSV schema and helper APIs
- image_ui now uses fixed 0.8 temp for prompt generation and 0.0 elsewhere
- updated tests for new temperature defaults

## Testing
- `pytest tests/test_ollama.py tests/test_lmstudio.py tests/test_csv_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_689dc65028f88329836a11565413554b