### PR TITLE
Use fixed image prefix and slugified alt text fallback

### DIFF
--- a/movie_agent/image_ui.py
+++ b/movie_agent/image_ui.py
@@ -509,9 +509,7 @@ def main() -> None:
                 return
 
             alt_text = str(row.get("alt_text", "")).strip()
-            slug = slugify(prompt)
-            if not alt_text:
-                alt_text = slug
+            alt_text = alt_text or slugify(prompt)
             neg_prompt = row.get("negative_prompt", "") or DEFAULT_NEGATIVE_PROMPT
             sfw_neg = row.get("sfw_negative_prompt", "")
             if row.get("nsfw"):
@@ -571,7 +569,7 @@ def main() -> None:
                         cfg=cfg_val,
                         steps=steps_val,
                         output_dir=folder,
-                        prefix=f"{slug}_{b}",
+                        prefix=f"img_{b}",
                         debug=DEBUG_MODE,
                     )
                     if paths:


### PR DESCRIPTION
## Summary
- Replace slug-based filenames with short ASCII prefix when generating images
- Simplify alt-text handling by falling back to slugified prompt

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dc8d6b7d483298d297dc27c429f94